### PR TITLE
Add ESLint

### DIFF
--- a/.github/workflows/00-publish-docs-to-github-pages-setup.yml
+++ b/.github/workflows/00-publish-docs-to-github-pages-setup.yml
@@ -1,5 +1,5 @@
 
-name: Publish 00 docs create repos
+name: "00-publish-docs-to-github-pages-setup: set up -docs and -docs-qa repos (run once, manually)"
 on: 
   workflow_dispatch:
 jobs:

--- a/.github/workflows/02-publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/02-publish-docs-to-github-pages-qa.yml
@@ -1,5 +1,6 @@
 
-name: 00 Publish 01 docs (Storybook) to GitHub Pages QA
+name: "02-publish-docs-to-github-pages-qa: Publish QA Storybook to GitHub Pages"
+
 on: 
   workflow_dispatch:
   pull_request:
@@ -10,11 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    strategy:
+      matrix:
+        node-version: [16.x]
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Figure out Branch name
         run: | 
           GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"

--- a/.github/workflows/04-publish-docs-to-github-pages-prod.yml
+++ b/.github/workflows/04-publish-docs-to-github-pages-prod.yml
@@ -1,5 +1,5 @@
 
-name: 00 Publish 02 docs (Storybook) to GitHub Pages
+name: "04-publish-docs-to-github-pages-prod: Publish production Storybook to GitHub Pages"
 on: 
   workflow_dispatch:
   push:
@@ -10,11 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    strategy:
+      matrix:
+        node-version: [16.x]
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Append name of site to _config.yml
         working-directory: ./frontend/docs-index
         run: | 

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -1,13 +1,12 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 01 Backend 01 Tests (JUnit)
+name: "10-backend-unit: Java Unit tests"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
+  push:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -1,18 +1,16 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 01 Backend 02 Coverage (Jacoco)
+name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
+  push:
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -1,18 +1,16 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 03 Check Production Build (if this fails, deploying to Heroku will fail)
+name: "14-backend-pitest: Java Mutation Testing (Pitest)"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
+  push:
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -26,7 +24,11 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-        PRODUCTION: true
-      run: mvn -DskipTests clean dependency:list install
-
-  
+      run: mvn -B test 
+    - name: Pitest
+      run: mvn test org.pitest:pitest-maven:mutationCoverage
+    - name: Upload Pitest to Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: pitest-mutation-testing
+        path: target/pit-reports/* 

--- a/.github/workflows/30-frontend-tests.yml
+++ b/.github/workflows/30-frontend-tests.yml
@@ -1,4 +1,4 @@
-name: 02 Frontend 02 Coverage (JavaScript/Jest)
+name: "30-frontend-tests: JavaScript, Jest Unit tests"
 
 on:
   workflow_dispatch:
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with: 
@@ -25,11 +25,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
         working-directory: ./frontend
-      - run: npm run coverage
+      - run: npm test
         working-directory: ./frontend
-      - name: Upload to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
-        working-directory: ./frontend
-     
+    

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -1,4 +1,4 @@
-name: 02 Frontend 03 Mutation Testing (JavaScript/Stryker, testing the test suite)
+name: "32-frontend-coverage: Frontend Coverage (JavaScript/Jest)"
 
 on:
   workflow_dispatch:
@@ -10,11 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 10
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with: 
@@ -25,5 +25,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
         working-directory: ./frontend
-      - run: npx stryker run
+      - run: npm run coverage
         working-directory: ./frontend
+      - name: Upload to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)
+        working-directory: ./frontend
+     

--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -1,4 +1,4 @@
-name: 02 Frontend 01 Tests (JavaScript/Jest)
+name: "34-frontend-mutation-testing: Stryker JS Mutation Testing (JavaScript/Jest)"
 
 on:
   workflow_dispatch:
@@ -10,11 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 40
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with: 
@@ -25,6 +25,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
         working-directory: ./frontend
-      - run: npm test
+      - run: npx stryker run
         working-directory: ./frontend
-    

--- a/.github/workflows/36-frontend-eslint.yml
+++ b/.github/workflows/36-frontend-eslint.yml
@@ -1,0 +1,27 @@
+name: "36-frontend-eslint: JavaScript style checking"
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ./frontend
+      - run: npx eslint --max-warnings 0 .
+        working-directory: ./frontend

--- a/.github/workflows/40-check-production-build.yml
+++ b/.github/workflows/40-check-production-build.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 01 Backend 03 Mutation Testing (Pitest)
+name: "40-check-production-build: Check Production Build (if this fails, deploying to Heroku will fail)"
 
 on:
   workflow_dispatch:
@@ -26,11 +26,7 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test 
-    - name: Pitest
-      run: mvn test org.pitest:pitest-maven:mutationCoverage
-    - name: Upload Pitest to Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: pitest-mutation-testing
-        path: target/pit-reports/* 
+        PRODUCTION: true
+      run: mvn -DskipTests clean dependency:list install
+
+  

--- a/.github/workflows/99-publish-clean-up-docs-qa.yml
+++ b/.github/workflows/99-publish-clean-up-docs-qa.yml
@@ -1,5 +1,5 @@
 
-name: 00 Publish 99 Clean up docs-qa
+name: "99-publish-clean-up-docs-qa: Run this to clean out old branches on QA Docs site"
 on: 
   workflow_dispatch:
 jobs:

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+    "root": true,
+    "extends": [
+        "react-app",
+        "react-app/jest"
+    ],
+    "env": {
+        "browser": true
+    },
+    "overrides": [
+        {
+            "files": [
+                "src/stories/**",
+                "src/test/**/*.js"
+            ],
+            "rules": {
+                "import/no-anonymous-default-export": "off"
+            },
+            "env": {
+                "node": true,
+                "jest": true
+            }
+        }
+    ],
+    "rules": {
+        "no-unused-vars": [
+            "error",
+            {
+                "vars": "all",
+                "varsIgnorePattern": "^_",
+                "args": "all",
+                "argsIgnorePattern": "^_",
+                "ignoreRestSiblings": true
+            }
+        ]
+    }
+}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -32,6 +32,7 @@
                 "argsIgnorePattern": "^_",
                 "ignoreRestSiblings": true
             }
-        ]
+        ],
+        "testing-library/no-node-access": ["off"]
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,8 +42,10 @@
         "@testing-library/react-hooks": "^5.1.2",
         "axios-mock-adapter": "^1.19.0",
         "env-cmd": "^10.1.0",
+        "eslint": "^8.15.0",
         "eslint-plugin-flowtype": "^8.0.3",
         "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-react": "^7.30.0",
         "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
         "jest-mock-console": "^1.1.0",
         "react-test-renderer": "^17.0.2"
@@ -2088,18 +2090,18 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -2127,9 +2129,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2138,14 +2140,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
@@ -2163,6 +2157,17 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -12536,13 +12541,13 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "node_modules/array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       },
@@ -12596,13 +12601,14 @@
       }
     },
     "node_modules/array.prototype.flatmap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
-      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16383,14 +16389,18 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-property": {
@@ -17075,30 +17085,33 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17136,6 +17149,14 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dependencies": {
+        "has": "^1.0.3"
+      }
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
@@ -17220,11 +17241,11 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.0",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -17235,7 +17256,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -17251,7 +17272,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -17523,24 +17544,24 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
-      "integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
+      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
       "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flatmap": "^1.2.5",
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.0",
+        "object.hasown": "^1.1.1",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.6"
+        "string.prototype.matchall": "^4.0.7"
       },
       "engines": {
         "node": ">=4"
@@ -17775,6 +17796,17 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint/node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -17803,12 +17835,12 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -17816,9 +17848,9 @@
       }
     },
     "node_modules/espree/node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19227,7 +19259,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
       "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -19250,7 +19281,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
       "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -19587,9 +19617,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -19624,6 +19654,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -20930,9 +20971,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -21043,9 +21084,12 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -25692,12 +25736,12 @@
       }
     },
     "node_modules/object.hasown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
-      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -29430,12 +29474,13 @@
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -31586,17 +31631,17 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
-      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
-        "has-symbols": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.3.1",
+        "regexp.prototype.flags": "^1.4.1",
         "side-channel": "^1.0.4"
       },
       "funding": {
@@ -31638,24 +31683,26 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -32836,13 +32883,13 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -36248,18 +36295,18 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -36280,17 +36327,12 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "globals": {
-          "version": "13.12.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
           "requires": {
             "type-fest": "^0.20.2"
           }
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -36304,6 +36346,14 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         }
       }
     },
@@ -44319,13 +44369,13 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5",
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
@@ -44358,13 +44408,14 @@
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
-      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
+      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
+        "es-abstract": "^1.19.2",
+        "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.map": {
@@ -47256,11 +47307,12 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "define-property": {
@@ -47828,30 +47880,33 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.1",
         "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
         "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
+        "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "regexp.prototype.flags": "^1.4.3",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
       }
     },
     "es-array-method-boxes-properly": {
@@ -47880,6 +47935,14 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ=="
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -47939,11 +48002,11 @@
       }
     },
     "eslint": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "requires": {
-        "@eslint/eslintrc": "^1.2.0",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -47954,7 +48017,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -47970,7 +48033,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -48043,6 +48106,14 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "optionator": {
           "version": "0.9.1",
@@ -48260,24 +48331,24 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
-      "integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.0.tgz",
+      "integrity": "sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==",
       "requires": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flatmap": "^1.2.5",
+        "array-includes": "^3.1.5",
+        "array.prototype.flatmap": "^1.3.0",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.5",
         "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.0",
+        "object.hasown": "^1.1.1",
         "object.values": "^1.1.5",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.6"
+        "string.prototype.matchall": "^4.0.7"
       },
       "dependencies": {
         "doctrine": {
@@ -48363,19 +48434,19 @@
       }
     },
     "espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "requires": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+          "version": "8.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
         }
       }
     },
@@ -49507,7 +49578,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
       "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -49523,8 +49593,7 @@
     "functions-have-names": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz",
-      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==",
-      "dev": true
+      "integrity": "sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA=="
     },
     "fuse.js": {
       "version": "3.6.1",
@@ -49764,9 +49833,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -49791,6 +49860,14 @@
             "is-extglob": "^2.1.0"
           }
         }
+      }
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "requires": {
+        "get-intrinsic": "^1.1.1"
       }
     },
     "has-symbols": {
@@ -50746,9 +50823,9 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -50820,9 +50897,12 @@
       "dev": true
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-stream": {
       "version": "2.0.1",
@@ -54341,12 +54421,12 @@
       }
     },
     "object.hasown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
-      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+      "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "object.pick": {
@@ -56971,12 +57051,13 @@
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
     },
     "regexp.prototype.flags": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {
@@ -58701,17 +58782,17 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
-      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
+      "integrity": "sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1",
         "get-intrinsic": "^1.1.1",
-        "has-symbols": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.3.1",
+        "regexp.prototype.flags": "^1.4.1",
         "side-channel": "^1.0.4"
       }
     },
@@ -58738,21 +58819,23 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.19.5"
       }
     },
     "stringify-object": {
@@ -59644,13 +59727,13 @@
       "optional": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,8 +37,10 @@
     "@testing-library/react-hooks": "^5.1.2",
     "axios-mock-adapter": "^1.19.0",
     "env-cmd": "^10.1.0",
+    "eslint": "^8.15.0",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
     "jest-mock-console": "^1.1.0",
     "react-test-renderer": "^17.0.2"

--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
-import { toast } from "react-toastify";
 
 import { allTheLevels } from "fixtures/levelsFixtures";
 import { quarterRange } from "main/utils/quarterUtilities";
@@ -37,14 +36,13 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
 
   useEffect(() => {
     getMutation.mutate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [quarter, setQuarter] = useState(localQuarter || quarters[0].yyyyq);
   const [subject, setSubject] = useState(localSubject || {});
   const [subjects, setSubjects] = useState([]);
   const [level, setLevel] = useState(localLevel || "U");
-  const [errorNotified, setErrorNotified] = useState(false);
-  // Stryker restore all
 
   const handleSubmit = (event) => {
     event.preventDefault();

--- a/frontend/src/main/components/Courses/BasicCourseTable.js
+++ b/frontend/src/main/components/Courses/BasicCourseTable.js
@@ -37,14 +37,9 @@ export default function BasicCourseTable({ courses }) {
         },
     ];
 
-    // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
-    const memoizedColumns = React.useMemo(() => columns, [columns]);
-    // Stryker disable next-line ArrayDeclaration : [courses] is a performance optimization
-    const memoizedCourses = React.useMemo(() => courses, [courses]);
-
     return <OurTable
-        data={memoizedCourses}
-        columns={memoizedColumns}
+        data={courses}
+        columns={columns}
         testid={"BasicCourseTable"}
     />;
 };

--- a/frontend/src/main/components/Levels/SingleLevelDropdown.js
+++ b/frontend/src/main/components/Levels/SingleLevelDropdown.js
@@ -1,12 +1,12 @@
-import React, {useState} from "react";
-import {Form} from "react-bootstrap";
+import { useState } from "react";
+import { Form } from "react-bootstrap";
 
-const SingleLevelDropdown = ({levels, level, setLevel, controlId, onChange = null, label="Course Level"}) => {
+const SingleLevelDropdown = ({levels, setLevel, controlId, onChange = null, label="Course Level"}) => {
     const localSearchLevel = localStorage.getItem(controlId);
     const [levelState, setLevelState] = useState(
         // Stryker disable next-line all : not sure how to test/mock local storage
         localSearchLevel || "U"
-        );
+    );
 
     const handleLeveltoChange = (event) => {
         localStorage.setItem(controlId, event.target.value);

--- a/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalSchedulesTable.js
@@ -6,8 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 
-export default function PersonalSchedulesTable({  personalSchedules, currentUser }) {
-
+export default function PersonalSchedulesTable({ personalSchedules, currentUser }) {
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
@@ -15,7 +14,6 @@ export default function PersonalSchedulesTable({  personalSchedules, currentUser
     }
 
     // Stryker disable all : hard to test for query caching
-
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
@@ -25,7 +23,6 @@ export default function PersonalSchedulesTable({  personalSchedules, currentUser
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
-
 
     const columns = [
         {
@@ -48,18 +45,17 @@ export default function PersonalSchedulesTable({  personalSchedules, currentUser
         },
     ];
 
-    if (hasRole(currentUser, "ROLE_USER")) {
-        columns.push(ButtonColumn("Edit", "primary", editCallback, "PersonalSchedulesTable"));
-        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "PersonalSchedulesTable"));
-    } 
+    const columnsIfUser = [
+        ...columns,
+        ButtonColumn("Edit", "primary", editCallback, "PersonalSchedulesTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "PersonalSchedulesTable")
+    ]
 
-    // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
-    const memoizedColumns = React.useMemo(() => columns, [columns]);
-    const memoizedPersonalSchedules = React.useMemo(() => personalSchedules, [personalSchedules]);
+    const columnsToDisplay = hasRole(currentUser, "ROLE_USER") ? columnsIfUser : columns;
 
     return <OurTable
-        data={memoizedPersonalSchedules}
-        columns={memoizedColumns}
+        data={personalSchedules}
+        columns={columnsToDisplay}
         testid={"PersonalSchedulesTable"}
     />;
 };

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -13,7 +13,7 @@ import { Form } from 'react-bootstrap';
 //  { yyyyq :"20221", qyy: "W22"}, 
 //  { yyyyq :"20222", qyy: "S22"}] 
 
-function SingleQuarterDropdown({ quarters, quarter, setQuarter, controlId, onChange = null, label = "Quarter" }) {
+function SingleQuarterDropdown({ quarters, setQuarter, controlId, onChange = null, label = "Quarter" }) {
 
     const localSearchQuarter = localStorage.getItem(controlId);
 

--- a/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
+++ b/frontend/src/main/components/UCSBSubjects/UCSBSubjectsTable.js
@@ -14,7 +14,6 @@ export default function UCSBSubjectsTable({ subjects, currentUser }) {
     }
 
     // Stryker disable all : hard to test for query caching
-
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
@@ -24,7 +23,6 @@ export default function UCSBSubjectsTable({ subjects, currentUser }) {
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
-
 
     const columns = [
         {
@@ -52,20 +50,19 @@ export default function UCSBSubjectsTable({ subjects, currentUser }) {
             accessor: (row) => String(row.inactive),
             id: 'inactive',
         }
-        
     ];
-    if (hasRole(currentUser, "ROLE_ADMIN")) {
-        columns.push(ButtonColumn("Edit", "primary", editCallback, "UCSBSubjectsTable"));
-        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "UCSBSubjectsTable"));
-    } 
 
-    // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
-    const memoizedColumns = React.useMemo(() => columns, [columns]);
-    const memoizedDates = React.useMemo(() => subjects, [subjects]);
+    const columnsIfAdmin = [
+        ...columns,
+        ButtonColumn("Edit", "primary", editCallback, "UCSBSubjectsTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "UCSBSubjectsTable")
+    ]
+
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
-        data={memoizedDates}
-        columns={memoizedColumns}
+        data={subjects}
+        columns={columnsToDisplay}
         testid={"UCSBSubjectsTable"}
     />;
 };

--- a/frontend/src/main/pages/AdminLoadSubjectsPage.js
+++ b/frontend/src/main/pages/AdminLoadSubjectsPage.js
@@ -3,20 +3,15 @@ import { useBackendMutation, useBackend } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 import { Button } from "react-bootstrap";
 import UCSBSubjectsTable from 'main/components/UCSBSubjects/UCSBSubjectsTable';
-import { useCurrentUser } from 'main/utils/currentUser'
-
-
 
 export default function AdminLoadSubjectsPage() {
-
-  const currentUser = useCurrentUser();
   const { data: subjects, error: _error, status: _status } =
       useBackend(
         // Stryker disable next-line all : don't test internal caching of React Query
         ["/api/UCSBSubjects/all"], { method: "GET", url: "/api/UCSBSubjects/all" }, []
       );
 
-  const objectToAxiosParams = (subjects) => ({
+  const objectToAxiosParams = () => ({
     url: '/api/UCSBSubjects/load',
     method: 'POST',
   });

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -1,10 +1,8 @@
-import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useState } from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import BasicCourseSearchForm from "main/components/BasicCourseSearch/BasicCourseSearchForm";
-import { useBackendMutation } from "main/utils/useBackend";
-import { queryAllByTestId } from "@testing-library/react";
-import { toast } from "react-toastify";
 import BasicCourseTable from "main/components/Courses/BasicCourseTable";
+import { useBackendMutation } from "main/utils/useBackend";
 
 export default function HomePage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -30,7 +28,7 @@ export default function HomePage() {
     []
   );
 
-  async function fetchBasicCourseJSON(event, query) {
+  async function fetchBasicCourseJSON(_event, query) {
     mutation.mutate(query);
   }
 

--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "react-toastify";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -46,21 +46,22 @@ describe("BasicCourseSearchForm tests", () => {
   });
 
   test("when I select a quarter, the state for quarter changes", () => {
-    const { getByLabelText } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
       </QueryClientProvider>
     );
-    const selectQuarter = getByLabelText("Quarter");
+    const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20204");
     expect(selectQuarter.value).toBe("20204");
   });
 
   test("when I select a subject, the state for subject changes", async () => {
     axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
-    const { getByLabelText } = render(
+    
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <BasicCourseSearchForm />
@@ -71,20 +72,20 @@ describe("BasicCourseSearchForm tests", () => {
     await waitFor(() => {
       expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
     });
-    const selectSubject = getByLabelText("Subject Area");
+    const selectSubject = screen.getByLabelText("Subject Area");
     userEvent.selectOptions(selectSubject, "MATH");
     expect(selectSubject.value).toBe("MATH");
   });
 
   test("when I select a level, the state for level changes", () => {
-    const { getByLabelText } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <BasicCourseSearchForm />
         </MemoryRouter>
       </QueryClientProvider>
     );
-    const selectLevel = getByLabelText("Course Level");
+    const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
     expect(selectLevel.value).toBe("G");
   });
@@ -99,7 +100,7 @@ describe("BasicCourseSearchForm tests", () => {
 
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
 
-    const { getByText, getByLabelText } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
@@ -117,13 +118,13 @@ describe("BasicCourseSearchForm tests", () => {
       expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
     });
 
-    const selectQuarter = getByLabelText("Quarter");
+    const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20211");
-    const selectSubject = getByLabelText("Subject Area");
+    const selectSubject = screen.getByLabelText("Subject Area");
     userEvent.selectOptions(selectSubject, "ANTH");
-    const selectLevel = getByLabelText("Course Level");
+    const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
-    const submitButton = getByText("Submit");
+    const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
 
     await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
@@ -145,7 +146,7 @@ describe("BasicCourseSearchForm tests", () => {
 
     fetchJSONSpy.mockResolvedValue(sampleReturnValue);
 
-    const { getByText, getByLabelText } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <BasicCourseSearchForm fetchJSON={fetchJSONSpy} />
@@ -157,13 +158,13 @@ describe("BasicCourseSearchForm tests", () => {
       expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
     });
 
-    const selectQuarter = getByLabelText("Quarter");
+    const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20204");
-    const selectSubject = getByLabelText("Subject Area");
+    const selectSubject = screen.getByLabelText("Subject Area");
     userEvent.selectOptions(selectSubject, "MATH");
-    const selectLevel = getByLabelText("Course Level");
+    const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
-    const submitButton = getByText("Submit");
+    const submitButton = screen.getByText("Submit");
     userEvent.click(submitButton);
   });
 });

--- a/frontend/src/tests/components/Courses/BasicCourseTable.test.js
+++ b/frontend/src/tests/components/Courses/BasicCourseTable.test.js
@@ -1,9 +1,8 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { coursesFixtures } from "fixtures/courseFixtures";
 import BasicCourseTable from "main/components/Courses/BasicCourseTable";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-
 
 const mockedNavigate = jest.fn();
 
@@ -15,29 +14,23 @@ jest.mock('react-router-dom', () => ({
 describe("CourseTable tests", () => {
   const queryClient = new QueryClient();
 
-
   test("renders without crashing for empty table", () => {
-
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <BasicCourseTable courses={[]} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
   });
 
   test("Has the expected column headers and content", () => {
-
-
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <BasicCourseTable courses={coursesFixtures.twoCourses} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     const expectedHeaders = ["Quarter", "Course Id", "Title", "Description", "Level Code", "Subject Area", "Units"];
@@ -45,17 +38,17 @@ describe("CourseTable tests", () => {
     const testId = "BasicCourseTable";
 
     expectedHeaders.forEach((headerText) => {
-      const header = getByText(headerText);
+      const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
     });
 
     expectedFields.forEach((field) => {
-      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W21");
-    expect(getByTestId(`${testId}-cell-row-1-col-courseId`)).toHaveTextContent("CMPSC 16");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("W21");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-courseId`)).toHaveTextContent("CMPSC 16");
 
   });
 

--- a/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
+++ b/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
@@ -1,18 +1,16 @@
-import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import SingleLevelDropdown from "main/components/Levels/SingleLevelDropdown"
+import { useState } from 'react';
 
-import {allTheLevels} from "fixtures/levelsFixtures"
+import SingleLevelDropdown from "main/components/Levels/SingleLevelDropdown";
+import { allTheLevels } from "fixtures/levelsFixtures";
 
 jest.mock('react', ()=>({
     ...jest.requireActual('react'),
     useState: jest.fn(),
   }))
-import { useState } from 'react';
 
 describe("SingleLevelDropdown tests", () => {
-
     beforeEach(() => {
         useState.mockImplementation(jest.requireActual('react').useState);
     });
@@ -34,67 +32,70 @@ describe("SingleLevelDropdown tests", () => {
     });
 
     test("when I select an level, the value changes", async () => {
-        const { getByLabelText } =
-            render(<SingleLevelDropdown
+        render(
+            <SingleLevelDropdown
                 levels={allTheLevels}
                 level={level}
                 setLevel={setLevel}
                 controlId="sld1"
             />
-            );
-        await waitFor(() => expect(getByLabelText("Course Level")).toBeInTheDocument);
-        const selectLevel = getByLabelText("Course Level")
+        );
+
+        expect(await screen.findByLabelText("Course Level")).toBeInTheDocument();
+        const selectLevel = screen.getByLabelText("Course Level");
         userEvent.selectOptions(selectLevel, "U");
         expect(setLevel).toBeCalledWith("U");
     });
 
     test("if I pass a non-null onChange, it gets called when the value changes", async () => {
         const onChange = jest.fn();
-        const { getByLabelText } =
-            render(<SingleLevelDropdown
+        render(
+            <SingleLevelDropdown
                 levels={allTheLevels}
                 level={level}
                 setLevel={setLevel}
                 controlId="sld1"
                 onChange={onChange}
             />
-            );
-        await waitFor(() => expect(getByLabelText("Course Level")).toBeInTheDocument);
-        const selectLevel = getByLabelText("Course Level")
+        );
+
+        expect(await screen.findByLabelText("Course Level")).toBeInTheDocument();
+        const selectLevel = screen.getByLabelText("Course Level");
         userEvent.selectOptions(selectLevel, "U");
+
         await waitFor(() => expect(setLevel).toBeCalledWith("U"));
         await waitFor(() => expect(onChange).toBeCalledTimes(1));
 
         // x.mock.calls[0][0] is the first argument of the first call to the jest.fn() mock x
-
         const event = onChange.mock.calls[0][0];
         expect(event.target.value).toBe("U");
     });
 
     test("default label is Course Level", async () => {
-        const { getByLabelText } =
-            render(<SingleLevelDropdown
+        render(
+            <SingleLevelDropdown
                 levels={allTheLevels}
                 level={level}
                 setLevel={setLevel}
                 controlId="sld1"
             />
-            );
-        await waitFor(() => expect(getByLabelText("Course Level")).toBeInTheDocument);
+        );
+
+        expect(await screen.findByLabelText("Course Level")).toBeInTheDocument();
     });
 
     test("keys / testids are set correctly on options", async () => {
-        const { getByTestId } =
-            render(<SingleLevelDropdown
+        render(
+            <SingleLevelDropdown
                 levels={allTheLevels}
                 level={level}
                 setLevel={setLevel}
                 controlId="sld1"
             />
-            );
-        const expectedKey = "sld1-option-0"
-        await waitFor(() => expect(getByTestId(expectedKey).toBeInTheDocument));
-        const firstOption = getByTestId(expectedKey);
+        );
+
+        const expectedKey = "sld1-option-0";
+        expect(await screen.findByTestId(expectedKey)).toBeInTheDocument();
     });
 
     test("when localstorage has a value, it is passed to useState", async () => {
@@ -104,14 +105,14 @@ describe("SingleLevelDropdown tests", () => {
         const setLevelStateSpy = jest.fn();
         useState.mockImplementation((x)=>[x, setLevelStateSpy])
 
-        const { getByTestId } =
-            render(<SingleLevelDropdown
+        render(
+            <SingleLevelDropdown
                 levels={allTheLevels}
                 level={level}
                 setLevel={setLevel}
                 controlId="sld1"
             />
-            );
+        );
 
         await waitFor(() => expect(useState).toBeCalledWith("U"));
     });
@@ -123,16 +124,15 @@ describe("SingleLevelDropdown tests", () => {
         const setLevelStateSpy = jest.fn();
         useState.mockImplementation((x)=>[x, setLevelStateSpy])
 
-        const { getByTestId } =
-            render(<SingleLevelDropdown
+        render(
+            <SingleLevelDropdown
                 levels={allTheLevels}
                 level={level}
                 setLevel={setLevel}
                 controlId="sld1"
             />
-            );
+        );
 
         await waitFor(() => expect(useState).toBeCalledWith("U"));
     });
-
 });

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -1,21 +1,19 @@
-import { render, waitFor} from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
 import AppNavbar from "main/components/Nav/AppNavbar";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 describe("AppNavbar tests", () => {
-
     const queryClient = new QueryClient();
 
     test("renders correctly for regular logged in user", async () => {
-
         const currentUser = currentUserFixtures.userOnly;
         const doLogin = jest.fn();
 
-        const { getByText } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} doLogin={doLogin} />
@@ -23,15 +21,14 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByText("Welcome, pconrad.cis@gmail.com")).toBeInTheDocument());
+        expect(await screen.findByText("Welcome, pconrad.cis@gmail.com")).toBeInTheDocument();
     });
 
     test("renders correctly for admin user", async () => {
-
         const currentUser = currentUserFixtures.adminUser;
         const doLogin = jest.fn();
 
-        const { getByText , getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} doLogin={doLogin} />
@@ -39,28 +36,27 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByText("Welcome, phtcon@ucsb.edu")).toBeInTheDocument());
-        const adminMenu = getByTestId("appnavbar-admin-dropdown");
+        expect(await screen.findByText("Welcome, phtcon@ucsb.edu")).toBeInTheDocument();
+        const adminMenu = screen.getByTestId("appnavbar-admin-dropdown");
 
         expect(adminMenu).toBeInTheDocument(); 
         
         const aElement = adminMenu.querySelector("a");
         expect(aElement).toBeInTheDocument();
         aElement?.click();
-        await waitFor( () => expect(getByTestId(/appnavbar-admin-users/)).toBeInTheDocument() );
-        await waitFor( () => expect(getByTestId("appnavbar-admin-loadsubjects")).toBeInTheDocument() );      
-        await waitFor( () => expect(getByTestId(/appnavbar-admin-personalschedule/)).toBeInTheDocument() );
 
+        expect(await screen.findByTestId(/appnavbar-admin-users/)).toBeInTheDocument();
+        expect(screen.getByTestId("appnavbar-admin-loadsubjects")).toBeInTheDocument();      
+        expect(screen.getByTestId(/appnavbar-admin-personalschedule/)).toBeInTheDocument();
     });
 
     test("renders H2Console and Swagger links correctly", async () => {
-
         const currentUser = currentUserFixtures.adminUser;
         const systemInfo = systemInfoFixtures.showingBoth;
 
         const doLogin = jest.fn();
 
-        const { getByText  } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
@@ -68,16 +64,11 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByText("H2Console")).toBeInTheDocument());
-        const swaggerMenu = getByText("Swagger");
-        expect(swaggerMenu).toBeInTheDocument();        
+        expect(await screen.findByText("H2Console")).toBeInTheDocument();
+        expect(screen.getByText("Swagger")).toBeInTheDocument();        
     });
 
-
-   
-
     test("renders the AppNavbarLocalhost when on http://localhost:3000", async () => {
-
         const currentUser = currentUserFixtures.userOnly;
         const systemInfo = systemInfoFixtures.showingBoth;
         const doLogin = jest.fn();
@@ -85,7 +76,7 @@ describe("AppNavbar tests", () => {
         delete window.location
         window.location = new URL('http://localhost:3000')
 
-        const {getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
@@ -93,11 +84,10 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByTestId("AppNavbarLocalhost")).toBeInTheDocument());
+        expect(await screen.findByTestId("AppNavbarLocalhost")).toBeInTheDocument();
     });
 
     test("renders the AppNavbarLocalhost when on http://127.0.0.1:3000", async () => {
-
         const currentUser = currentUserFixtures.userOnly;
         const systemInfo = systemInfoFixtures.showingBoth;
         const doLogin = jest.fn();
@@ -105,7 +95,7 @@ describe("AppNavbar tests", () => {
         delete window.location
         window.location = new URL('http://127.0.0.1:3000')
 
-        const {getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
@@ -113,32 +103,10 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByTestId("AppNavbarLocalhost")).toBeInTheDocument());
-    });
-
-    test("renders the AppNavbarLocalhost when on http://127.0.0.1:3000", async () => {
-
-        const currentUser = currentUserFixtures.userOnly;
-        const systemInfo = systemInfoFixtures.showingBoth;
-        const doLogin = jest.fn();
-
-        delete window.location
-        window.location = new URL('http://127.0.0.1:3000')
-
-        const {getByTestId } = render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => expect(getByTestId("AppNavbarLocalhost")).toBeInTheDocument());
-
+        expect(await screen.findByTestId("AppNavbarLocalhost")).toBeInTheDocument();
     });
 
     test("does NOT render the AppNavbarLocalhost when on localhost:8080", async () => {
-
         const currentUser = currentUserFixtures.userOnly;
         const systemInfo = systemInfoFixtures.showingBoth;
         const doLogin = jest.fn();
@@ -146,7 +114,7 @@ describe("AppNavbar tests", () => {
         delete window.location
         window.location = new URL('http://localhost:8080')
 
-        const {getByTestId, queryByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
@@ -154,18 +122,17 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByTestId("AppNavbar")).toBeInTheDocument());
-        expect(queryByTestId(/AppNavbarLocalhost/i)).toBeNull();
+        expect(await screen.findByTestId("AppNavbar")).toBeInTheDocument();
+        expect(screen.queryByTestId(/AppNavbarLocalhost/i)).toBeNull();
     });
 
     test("renders the PersonalSchedules menu correctly", async () => {
-
         const currentUser = currentUserFixtures.userOnly;
         const systemInfo = systemInfoFixtures.showingBoth;
 
         const doLogin = jest.fn();
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
@@ -173,16 +140,13 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByTestId("appnavbar-personalschedules-dropdown")).toBeInTheDocument());
-        const dropdown = getByTestId("appnavbar-personalschedules-dropdown");
+        expect(await screen.findByTestId("appnavbar-personalschedules-dropdown")).toBeInTheDocument();
+        const dropdown = screen.getByTestId("appnavbar-personalschedules-dropdown");
         const aElement = dropdown.querySelector("a");
         expect(aElement).toBeInTheDocument();
         aElement?.click();
-        await waitFor(() => expect(getByTestId("appnavbar-personalschedules-list")).toBeInTheDocument());
-        await waitFor(() => expect(getByTestId(/appnavbar-personalschedules-create/)).toBeInTheDocument());
 
+        expect(await screen.findByTestId("appnavbar-personalschedules-list")).toBeInTheDocument();
+        expect(screen.getByTestId(/appnavbar-personalschedules-create/)).toBeInTheDocument();
     });
-
 });
-
-

--- a/frontend/src/tests/components/Nav/AppNavbarLocalhost.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbarLocalhost.test.js
@@ -1,14 +1,12 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import AppNavbarLocalhost from "main/components/Nav/AppNavbarLocalhost";
 
 describe("AppNavbarLocalhost tests", () => {
-
-    test("renders correctly ", async () => {
-        const { getByText } = render(
+    test("renders correctly", async () => {
+        render(
             <AppNavbarLocalhost />
         );
 
-        await waitFor(() => expect(getByText(/Running on /)).toBeInTheDocument());
+        expect(await screen.findByText(/Running on /)).toBeInTheDocument();
     });
-
 });

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,13 +1,11 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Footer from "main/components/Nav/Footer";
 
 describe("Footer tests", () => {
-    test("renders correctly ", async () => {
-        const { getByText } = render(
+    test("renders correctly", async () => {
+        render(
             <Footer />
         );
-        await waitFor(() => expect(getByText(/This is a sample webapp using React with a Spring Boot backend./)).toBeInTheDocument());
+        expect(await screen.findByText(/This is a sample webapp using React with a Spring Boot backend./)).toBeInTheDocument();
     });
 });
-
-

--- a/frontend/src/tests/components/OurTable.test.js
+++ b/frontend/src/tests/components/OurTable.test.js
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import OurTable, {ButtonColumn} from "main/components/OurTable";
 
 describe("OurTable tests", () => {
@@ -44,45 +44,42 @@ describe("OurTable tests", () => {
     });
 
     test("The button appears in the table", async () => {
-        const {getByTestId} = render(
+        render(
             <OurTable columns={columns} data={threeRows} />
         );
 
-        await waitFor(()=> expect(getByTestId("testId-cell-row-0-col-Click-button")).toBeInTheDocument() );
-        const button = getByTestId("testId-cell-row-0-col-Click-button");
+        expect(await screen.findByTestId("testId-cell-row-0-col-Click-button")).toBeInTheDocument();
+        const button = screen.getByTestId("testId-cell-row-0-col-Click-button");
         fireEvent.click(button);
-        await waitFor(()=>expect(clickMeCallback).toBeCalledTimes(1));
+        await waitFor(() => expect(clickMeCallback).toBeCalledTimes(1));
     });
 
     test("default testid is testId", async () => {
-        const {getByTestId } = render(
+        render(
             <OurTable columns={columns} data={threeRows} />
         );
-        await waitFor( ()=> expect(getByTestId("testid-header-col1")).toBeInTheDocument() );
+
+        expect(await screen.findByTestId("testid-header-col1")).toBeInTheDocument();
     });
 
     test("click on a header and a sort caret should appear", async () => {
-        const {getByTestId, getByText } = render(
+        render(
             <OurTable columns={columns} data={threeRows} testid={"sampleTestId"} />
         );
 
-        await waitFor( ()=> expect(getByTestId("sampleTestId-header-col1")).toBeInTheDocument() );
-        const col1Header = getByTestId("sampleTestId-header-col1");
+        expect(await screen.findByTestId("sampleTestId-header-col1")).toBeInTheDocument();
+        const col1Header = screen.getByTestId("sampleTestId-header-col1");
 
-        const col1SortCarets = getByTestId("sampleTestId-header-col1-sort-carets");
+        const col1SortCarets = screen.getByTestId("sampleTestId-header-col1-sort-carets");
         expect(col1SortCarets).toHaveTextContent('');
 
-        const col1Row0 = getByTestId("sampleTestId-cell-row-0-col-col1");
+        const col1Row0 = screen.getByTestId("sampleTestId-cell-row-0-col-col1");
         expect(col1Row0).toHaveTextContent("Hello");
 
         fireEvent.click(col1Header);
-        await waitFor( ()=> expect(getByText("🔼")).toBeInTheDocument() );
+        expect(await screen.findByText("🔼")).toBeInTheDocument();
 
         fireEvent.click(col1Header);
-        await waitFor( ()=> expect(getByText("🔽")).toBeInTheDocument() );
-
-        
-
+        expect(await screen.findByText("🔽")).toBeInTheDocument();
     });
-
 });

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -1,7 +1,8 @@
-import { render, waitFor, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
 import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
 import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
-import { BrowserRouter as Router } from "react-router-dom";
 
 const mockedNavigate = jest.fn();
 
@@ -10,69 +11,62 @@ jest.mock('react-router-dom', () => ({
     useNavigate: () => mockedNavigate
 }));
 
-
 describe("PersonalScheduleForm tests", () => {
-
-    test("renders correctly ", async () => {
-
-        const { getByText } = render(
-            <Router  >
+    test("renders correctly", async () => {
+        render(
+            <Router>
                 <PersonalScheduleForm />
             </Router>
         );
-        await waitFor(() => expect(getByText(/Name/)).toBeInTheDocument());
-        await waitFor(() => expect(getByText(/Description/)).toBeInTheDocument());
-        await waitFor(() => expect(getByText(/Quarter/)).toBeInTheDocument());
-        await waitFor(() => expect(getByText(/Create/)).toBeInTheDocument());
+
+        expect(await screen.findByText(/Name/)).toBeInTheDocument();
+        expect(screen.getByText(/Description/)).toBeInTheDocument();
+        expect(screen.getByText(/Quarter/)).toBeInTheDocument();
+        expect(screen.getByText(/Create/)).toBeInTheDocument();
     });
 
-
-    test("renders correctly when passing in a PersonalSchedule ", async () => {
-
-        const { getByText, getByTestId } = render(
-            <Router  >
+    test("renders correctly when passing in a PersonalSchedule", async () => {
+        render(
+            <Router>
                 <PersonalScheduleForm initialPersonalSchedule={personalSchedulesFixtures.onePersonalSchedule} />
             </Router>
         );
-        await waitFor(() => expect(getByTestId(/PersonalScheduleForm-id/)).toBeInTheDocument());
-        expect(getByText(/Id/)).toBeInTheDocument();
-        expect(getByTestId(/PersonalScheduleForm-id/)).toHaveValue("1");
+
+        expect(await screen.findByTestId(/PersonalScheduleForm-id/)).toBeInTheDocument();
+        expect(screen.getByText(/Id/)).toBeInTheDocument();
+        expect(screen.getByTestId(/PersonalScheduleForm-id/)).toHaveValue("1");
     });
 
-
-    test("Correct Error messsages on missing input", async () => {
-
-        const { getByTestId, getByText } = render(
+    test("Correct Error messages on missing input", async () => {
+        render(
             <Router  >
                 <PersonalScheduleForm />
             </Router>
         );
-        await waitFor(() => expect(getByTestId("PersonalScheduleForm-submit")).toBeInTheDocument());
-        const submitButton = getByTestId("PersonalScheduleForm-submit");
+        expect(await screen.findByTestId("PersonalScheduleForm-submit")).toBeInTheDocument();
+        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
         fireEvent.click(submitButton);
 
-        await waitFor(() => expect(getByText(/Name is required./)).toBeInTheDocument());
-        expect(getByText(/Description is required./)).toBeInTheDocument();
-
+        expect(await screen.findByText(/Name is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Description is required./)).toBeInTheDocument();
     });
 
-    test("No Error messsages on good input", async () => {
-
+    test("No Error messages on good input", async () => {
         const mockSubmitAction = jest.fn();
 
-
-        const { getByTestId, queryByText } = render(
-            <Router  >
+        render(
+            <Router>
                 <PersonalScheduleForm submitAction={mockSubmitAction} />
             </Router>
         );
-        await waitFor(() => expect(getByTestId("PersonalScheduleForm-name")).toBeInTheDocument());
 
-        const name = getByTestId("PersonalScheduleForm-name");
-        const description = getByTestId("PersonalScheduleForm-description");
+        expect(await screen.findByTestId("PersonalScheduleForm-name")).toBeInTheDocument();
+
+        const name = screen.getByTestId("PersonalScheduleForm-name");
+        const description = screen.getByTestId("PersonalScheduleForm-description");
         const quarter = document.querySelector("#PersonalScheduleForm-quarter");
-        const submitButton = getByTestId("PersonalScheduleForm-submit");
+        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
         fireEvent.change(name, { target: { value: 'test' } });
         fireEvent.change(description, { target: { value: 'test' } });
@@ -81,26 +75,22 @@ describe("PersonalScheduleForm tests", () => {
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-        expect(queryByText(/Name is required./)).not.toBeInTheDocument();
-        expect(queryByText(/Description is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Name is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Description is required./)).not.toBeInTheDocument();
         expect(quarter).toHaveValue("20124");
     });
 
-
-    test("Test that navigate(-1) is called when Cancel is clicked", async () => {
-
-        const { getByTestId } = render(
-            <Router  >
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <Router>
                 <PersonalScheduleForm />
             </Router>
         );
-        await waitFor(() => expect(getByTestId("PersonalScheduleForm-cancel")).toBeInTheDocument());
-        const cancelButton = getByTestId("PersonalScheduleForm-cancel");
+        expect(await screen.findByTestId("PersonalScheduleForm-cancel")).toBeInTheDocument();
+        const cancelButton = screen.getByTestId("PersonalScheduleForm-cancel");
 
         fireEvent.click(cancelButton);
 
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
-
     });
-
 });

--- a/frontend/src/tests/components/PersonalSchedules/PersonalSchedulesTable.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalSchedulesTable.test.js
@@ -1,10 +1,10 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
-import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
-import PersonalSchedulesTable from "main/components/PersonalSchedules/PersonalSchedulesTable";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
+import PersonalSchedulesTable from "main/components/PersonalSchedules/PersonalSchedulesTable";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
 
 const mockedNavigate = jest.fn();
 
@@ -23,7 +23,6 @@ jest.mock('main/utils/useBackend', () => ({
 describe("UserTable tests", () => {
   const queryClient = new QueryClient();
 
-
   test("renders without crashing for empty table with user not logged in", () => {
     const currentUser = null;
 
@@ -33,9 +32,9 @@ describe("UserTable tests", () => {
           <PersonalSchedulesTable personalSchedules={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
   });
+
   test("renders without crashing for empty table for ordinary user", () => {
     const currentUser = currentUserFixtures.userOnly;
 
@@ -45,7 +44,6 @@ describe("UserTable tests", () => {
           <PersonalSchedulesTable personalSchedules={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
   });
 
@@ -58,7 +56,6 @@ describe("UserTable tests", () => {
           <PersonalSchedulesTable personalSchedules={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
   });
 
@@ -66,13 +63,12 @@ describe("UserTable tests", () => {
 
     const currentUser = currentUserFixtures.userOnly;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <PersonalSchedulesTable personalSchedules={personalScheduleFixtures.threePersonalSchedules} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     const expectedHeaders = ["id", "Name","Description","Quarter"];
@@ -80,23 +76,23 @@ describe("UserTable tests", () => {
     const testId = "PersonalSchedulesTable";
 
     expectedHeaders.forEach((headerText) => {
-      const header = getByText(headerText);
+      const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
     });
 
     expectedFields.forEach((field) => {
-      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
 
-    const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
     expect(editButton).toHaveClass("btn-primary");
 
-    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
 
@@ -106,13 +102,12 @@ describe("UserTable tests", () => {
 
     const currentUser = currentUserFixtures.adminUser;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <PersonalSchedulesTable personalSchedules={personalScheduleFixtures.threePersonalSchedules} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     const expectedHeaders = ["id", "Name","Description","Quarter"];
@@ -120,94 +115,86 @@ describe("UserTable tests", () => {
     const testId = "PersonalSchedulesTable";
 
     expectedHeaders.forEach((headerText) => {
-      const header = getByText(headerText);
+      const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
     });
 
     expectedFields.forEach((field) => {
-      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
 
-    const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
     expect(editButton).toHaveClass("btn-primary");
 
-    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
-
   });
-
-  
 
   test("Edit button navigates to the edit page for Ordinary user", async () => {
 
     const currentUser = currentUserFixtures.userOnly;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <PersonalSchedulesTable personalSchedules={personalScheduleFixtures.threePersonalSchedules} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+    expect(await screen.findByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1");
 
-    const editButton = getByTestId(`PersonalSchedulesTable-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(`PersonalSchedulesTable-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
     
     fireEvent.click(editButton);
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/personalschedules/edit/1'));
-
   });
 
   test("Edit button navigates to the edit page for admin user", async () => {
 
     const currentUser = currentUserFixtures.adminUser;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <PersonalSchedulesTable personalSchedules={personalScheduleFixtures.threePersonalSchedules} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+    expect(await screen.findByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1");
 
-    const editButton = getByTestId(`PersonalSchedulesTable-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(`PersonalSchedulesTable-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
     
     fireEvent.click(editButton);
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/personalschedules/edit/1'));
-
   });
 
   test("Delete button calls delete callback for ordinary user", async () => {
 
     const currentUser = currentUserFixtures.userOnly;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <PersonalSchedulesTable personalSchedules={personalScheduleFixtures.threePersonalSchedules} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+    expect(await screen.findByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1");
 
-    const deleteButton = getByTestId(`PersonalSchedulesTable-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(`PersonalSchedulesTable-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     
     fireEvent.click(deleteButton);
@@ -219,25 +206,21 @@ describe("UserTable tests", () => {
 
     const currentUser = currentUserFixtures.adminUser;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <PersonalSchedulesTable personalSchedules={personalScheduleFixtures.threePersonalSchedules} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+    expect(await screen.findByTestId(`PersonalSchedulesTable-cell-row-0-col-id`)).toHaveTextContent("1");
 
-    const deleteButton = getByTestId(`PersonalSchedulesTable-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(`PersonalSchedulesTable-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     
     fireEvent.click(deleteButton);
 
     await waitFor(() => expect(mockedMutate).toHaveBeenCalledTimes(1));
   });
-
-
 });
-

--- a/frontend/src/tests/components/Profile/RoleBadge.test.js
+++ b/frontend/src/tests/components/Profile/RoleBadge.test.js
@@ -1,28 +1,27 @@
-import { render, waitFor } from "@testing-library/react";
-import {currentUserFixtures} from "fixtures/currentUserFixtures";
+import { render, screen } from "@testing-library/react";
+
 import RoleBadge from "main/components/Profile/RoleBadge"
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
 describe("RoleBadge tests", () => {
-
     test("renders without crashing for ROLE_USER when user has ROLE_USER", async () => {
-        const {getByTestId} = render(
+        render(
             <RoleBadge currentUser={currentUserFixtures.userOnly} role={"ROLE_USER"} />
         );
-        await waitFor( ()=> expect(getByTestId("role-badge-user")).toBeInTheDocument() );
+        expect(await screen.findByTestId("role-badge-user")).toBeInTheDocument();
     });
 
     test("renders without crashing for ROLE_ADMIN when user has ROLE_ADMIN", async () => {
-        const {getByTestId} = render(
+        render(
             <RoleBadge currentUser={currentUserFixtures.adminUser} role={"ROLE_ADMIN"} />
         );
-        await waitFor( ()=> expect(getByTestId("role-badge-admin")).toBeInTheDocument() );
+        expect(await screen.findByTestId("role-badge-admin")).toBeInTheDocument();
     });
 
     test("renders without crashing for ROLE_ADMIN when user does NOT have ROLE_ADMIN", async () => {
-        const {getByTestId } = render(
+        render(
             <RoleBadge currentUser={currentUserFixtures.userOnly} role={"ROLE_ADMIN"} />
         );
-        await waitFor( ()=> expect(getByTestId("role-missing-admin")).toBeInTheDocument() );
+        expect(await screen.findByTestId("role-missing-admin")).toBeInTheDocument();
     });
-
 });

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -1,17 +1,16 @@
-import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from 'react';
+
 import SingleQuarterDropdown from "main/components/Quarters/SingleQuarterDropdown"
 import { quarterRange } from 'main/utils/quarterUtilities';
 
-jest.mock('react', ()=>({
+jest.mock('react', () => ({
     ...jest.requireActual('react'),
     useState: jest.fn()
-  }))
-import { useState } from 'react';
+}))
 
 describe("SingleQuarterSelector tests", () => {
-
     beforeEach(() => {
         useState.mockImplementation(jest.requireActual('react').useState);
     });
@@ -42,25 +41,25 @@ describe("SingleQuarterSelector tests", () => {
     });
 
     test("when I select an object, the value changes", async () => {
-        const { getByLabelText } =
-            render(<SingleQuarterDropdown
+        render(
+            <SingleQuarterDropdown
                 quarters={quarterRange("20211", "20222")}
                 quarter={quarter}
                 setQuarter={setQuarter}
                 controlId="sqd1"
                 label="Select Quarter"
             />
-            );
-        await waitFor(() => expect(getByLabelText("Select Quarter")).toBeInTheDocument);
-        const selectQuarter = getByLabelText("Select Quarter")
+        );
+        expect(await screen.findByLabelText("Select Quarter")).toBeInTheDocument();
+        const selectQuarter = screen.getByLabelText("Select Quarter")
         userEvent.selectOptions(selectQuarter, "20213");
         expect(setQuarter).toBeCalledWith("20213");
     });
 
     test("if I pass a non-null onChange, it gets called when the value changes", async () => {
         const onChange = jest.fn();
-        const { getByLabelText } =
-            render(<SingleQuarterDropdown
+        render(
+            <SingleQuarterDropdown
                 quarters={quarterRange("20211", "20222")}
                 quarter={quarter}
                 setQuarter={setQuarter}
@@ -68,43 +67,44 @@ describe("SingleQuarterSelector tests", () => {
                 label="Select Quarter"
                 onChange={onChange}
             />
-            );
-        await waitFor(() => expect(getByLabelText("Select Quarter")).toBeInTheDocument);
-        const selectQuarter = getByLabelText("Select Quarter")
+        );
+
+        expect(await screen.findByLabelText("Select Quarter")).toBeInTheDocument();
+        const selectQuarter = screen.getByLabelText("Select Quarter")
         userEvent.selectOptions(selectQuarter, "20213");
         await waitFor(() => expect(setQuarter).toBeCalledWith("20213"));
         await waitFor(() => expect(onChange).toBeCalledTimes(1));
 
         // x.mock.calls[0][0] is the first argument of the first call to the jest.fn() mock x
-
         const event = onChange.mock.calls[0][0];
         expect(event.target.value).toBe("20213");
     });
 
     test("default label is Quarter", async () => {
-        const { getByLabelText } =
-            render(<SingleQuarterDropdown
+        render(
+            <SingleQuarterDropdown
                 quarters={quarterRange("20211", "20222")}
                 quarter={quarter}
                 setQuarter={setQuarter}
                 controlId="sqd1"
             />
-            );
-        await waitFor(() => expect(getByLabelText("Quarter")).toBeInTheDocument);
+        );
+
+        expect(await screen.findByLabelText("Quarter")).toBeInTheDocument();
     });
 
     test("keys / testids are set correctly on options", async () => {
-        const { getByTestId } =
-            render(<SingleQuarterDropdown
+        render(
+            <SingleQuarterDropdown
                 quarters={quarterRange("20211", "20222")}
                 quarter={quarter}
                 setQuarter={setQuarter}
                 controlId="sqd1"
             />
-            );
-        const expectedKey = "sqd1-option-0"
-        await waitFor(() => expect(getByTestId(expectedKey).toBeInTheDocument));
-        const firstOption = getByTestId(expectedKey);
+        );
+
+        const expectedKey = "sqd1-option-0";
+        expect(await screen.findByTestId(expectedKey)).toBeInTheDocument();
     });
 
     test("when localstorage has a value, it is passed to useState", async () => {
@@ -112,16 +112,16 @@ describe("SingleQuarterSelector tests", () => {
         getItemSpy.mockImplementation(() => "20202");
 
         const setQuarterStateSpy = jest.fn();
-        useState.mockImplementation((x)=>[x, setQuarterStateSpy])
+        useState.mockImplementation((x)=>[x, setQuarterStateSpy]);
 
-        const { getByTestId } =
-            render(<SingleQuarterDropdown
+        render(
+            <SingleQuarterDropdown
                 quarters={quarterRange("20201", "20224")}
                 quarter={quarter}
                 setQuarter={setQuarter}
                 controlId="sqd1"
             />
-            );
+        );
 
         await waitFor(() => expect(useState).toBeCalledWith("20202"));
     });
@@ -131,18 +131,17 @@ describe("SingleQuarterSelector tests", () => {
         getItemSpy.mockImplementation(() => null);
 
         const setQuarterStateSpy = jest.fn();
-        useState.mockImplementation((x)=>[x, setQuarterStateSpy])
+        useState.mockImplementation((x)=>[x, setQuarterStateSpy]);
 
-        const { getByTestId } =
-            render(<SingleQuarterDropdown
+        render(
+            <SingleQuarterDropdown
                 quarters={quarterRange("20201", "20224")}
                 quarter={quarter}
                 setQuarter={setQuarter}
                 controlId="sqd1"
             />
-            );
+        );
 
         await waitFor(() => expect(useState).toBeCalledWith("20201"));
     });
-
 });

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -1,20 +1,18 @@
-import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/extend-expect";
+import { useState } from "react";
+
 import SingleSubjectDropdown from "main/components/Subjects/SingleSubjectDropdown";
 import { oneSubject } from "fixtures/subjectFixtures";
 import { threeSubjects } from "fixtures/subjectFixtures";
 import { outOfOrderSubjects } from "fixtures/subjectFixtures";
-import "@testing-library/jest-dom/extend-expect";
 
 jest.mock("react", () => ({
   ...jest.requireActual("react"),
   useState: jest.fn(),
   compareValues: jest.fn(),
 }));
-
-import { useState } from "react";
-import { compareValues } from "main/utils/sortHelper";
 
 describe("SingleSubjectDropdown tests", () => {
   beforeEach(() => {
@@ -51,7 +49,7 @@ describe("SingleSubjectDropdown tests", () => {
   });
 
   test("when I select an object, the value changes", async () => {
-    const { getByLabelText } = render(
+    render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
         subject={subject}
@@ -59,16 +57,16 @@ describe("SingleSubjectDropdown tests", () => {
         controlId="ssd1"
       />
     );
-    await waitFor(
-      () => expect(getByLabelText("Subject Area")).toBeInTheDocument
-    );
-    const selectQuarter = getByLabelText("Subject Area");
+    
+    expect(await screen.findByLabelText("Subject Area")).toBeInTheDocument();
+
+    const selectQuarter = screen.getByLabelText("Subject Area");
     userEvent.selectOptions(selectQuarter, "ARTHI");
     expect(setSubject).toBeCalledWith("ARTHI");
   });
 
   test("out of order subjects is sorted by subjectCode", async () => {
-    const { getByText } = render(
+    render(
       <SingleSubjectDropdown
         subjects={outOfOrderSubjects}
         subject={subject}
@@ -76,8 +74,9 @@ describe("SingleSubjectDropdown tests", () => {
         controlId="ssd1"
       />
     );
-    await waitFor(() => expect(getByText("Subject Area")).toBeInTheDocument);
-    expect(getByText("ANTH - Anthropology")).toHaveAttribute(
+
+    expect(await screen.findByText("Subject Area")).toBeInTheDocument();
+    expect(screen.getByText("ANTH - Anthropology")).toHaveAttribute(
       "data-testid",
       "ssd1-option-0"
     );
@@ -85,7 +84,7 @@ describe("SingleSubjectDropdown tests", () => {
 
   test("if I pass a non-null onChange, it gets called when the value changes", async () => {
     const onChange = jest.fn();
-    const { getByLabelText } = render(
+    render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
         subject={subject}
@@ -94,22 +93,21 @@ describe("SingleSubjectDropdown tests", () => {
         onChange={onChange}
       />
     );
-    await waitFor(
-      () => expect(getByLabelText("Subject Area")).toBeInTheDocument
-    );
-    const selectSubject = getByLabelText("Subject Area");
+    
+    expect(await screen.findByLabelText("Subject Area")).toBeInTheDocument();
+
+    const selectSubject = screen.getByLabelText("Subject Area");
     userEvent.selectOptions(selectSubject, "ARTHI");
     await waitFor(() => expect(setSubject).toBeCalledWith("ARTHI"));
     await waitFor(() => expect(onChange).toBeCalledTimes(1));
 
     // x.mock.calls[0][0] is the first argument of the first call to the jest.fn() mock x
-
     const event = onChange.mock.calls[0][0];
     expect(event.target.value).toBe("ARTHI");
   });
 
   test("default label is Subject Area", async () => {
-    const { getByLabelText } = render(
+    render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
         subject={subject}
@@ -117,13 +115,12 @@ describe("SingleSubjectDropdown tests", () => {
         controlId="ssd1"
       />
     );
-    await waitFor(
-      () => expect(getByLabelText("Subject Area")).toBeInTheDocument
-    );
+    
+    expect(await screen.findByLabelText("Subject Area")).toBeInTheDocument();
   });
 
   test("keys / testids are set correctly on options", async () => {
-    const { getByTestId } = render(
+    render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
         subject={subject}
@@ -131,9 +128,9 @@ describe("SingleSubjectDropdown tests", () => {
         controlId="ssd1"
       />
     );
+
     const expectedKey = "ssd1-option-0";
-    await waitFor(() => expect(getByTestId(expectedKey).toBeInTheDocument));
-    const firstOption = getByTestId(expectedKey);
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
   });
 
   test("when localstorage has a value, it is passed to useState", async () => {
@@ -143,7 +140,7 @@ describe("SingleSubjectDropdown tests", () => {
     const setSubjectStateSpy = jest.fn();
     useState.mockImplementation((x) => [x, setSubjectStateSpy]);
 
-    const { getByTestId } = render(
+    render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
         subject={subject}
@@ -162,7 +159,7 @@ describe("SingleSubjectDropdown tests", () => {
     const setSubjectStateSpy = jest.fn();
     useState.mockImplementation((x) => [x, setSubjectStateSpy]);
 
-    const { getByTestId } = render(
+    render(
       <SingleSubjectDropdown
         subjects={threeSubjects}
         subject={subject}
@@ -177,7 +174,7 @@ describe("SingleSubjectDropdown tests", () => {
   });
 
   test("When no subjects, dropdown is blank", async () => {
-    const { queryByTestId, queryByText, queryByLabelText, get } = render(
+    render(
       <SingleSubjectDropdown
         subjects={[]}
         subject={subject}
@@ -185,7 +182,8 @@ describe("SingleSubjectDropdown tests", () => {
         controlId="ssd1"
       />
     );
+
     const expectedKey = "ssd1";
-    expect(queryByTestId(expectedKey)).toBeNull();
+    expect(screen.queryByTestId(expectedKey)).toBeNull();
   });
 });

--- a/frontend/src/tests/components/UCSBSubjects/UCSBSubjectsTable.test.js
+++ b/frontend/src/tests/components/UCSBSubjects/UCSBSubjectsTable.test.js
@@ -1,10 +1,10 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
-import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
-import UCSBSubjectsTable from "main/components/UCSBSubjects/UCSBSubjectsTable"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
+import UCSBSubjectsTable from "main/components/UCSBSubjects/UCSBSubjectsTable"
 
 const mockedNavigate = jest.fn();
 
@@ -63,10 +63,9 @@ describe("UserTable tests", () => {
   });
 
   test("Has the expected colum headers and content for adminUser", () => {
-
     const currentUser = currentUserFixtures.adminUser;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <UCSBSubjectsTable subjects={ucsbSubjectsFixtures.threeSubjects} currentUser={currentUser} />
@@ -80,75 +79,66 @@ describe("UserTable tests", () => {
     const testId = "UCSBSubjectsTable";
 
     expectedHeaders.forEach((headerText) => {
-      const header = getByText(headerText);
+      const header = screen.getByText(headerText);
       expect(header).toBeInTheDocument();
     });
 
     expectedFields.forEach((field) => {
-      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG");
-    expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("GER");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("GER");
 
-    const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
     expect(editButton).toHaveClass("btn-primary");
 
-    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     expect(deleteButton).toHaveClass("btn-danger");
-
   });
 
   test("Edit button navigates to the edit page for admin user", async () => {
-
     const currentUser = currentUserFixtures.adminUser;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <UCSBSubjectsTable subjects={ucsbSubjectsFixtures.threeSubjects} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`UCSBSubjectsTable-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG"); });
+    expect(await screen.findByTestId(`UCSBSubjectsTable-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG");
 
-    const editButton = getByTestId(`UCSBSubjectsTable-cell-row-0-col-Edit-button`);
+    const editButton = screen.getByTestId(`UCSBSubjectsTable-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
     
     fireEvent.click(editButton);
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/UCSBSubjects/edit/GEOG'));
-
   });
 
   test("Delete button calls delete callback", async () => {
-
     const currentUser = currentUserFixtures.adminUser;
 
-    const { getByText, getByTestId } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <UCSBSubjectsTable subjects={ucsbSubjectsFixtures.threeSubjects} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`UCSBSubjectsTable-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG"); });
+    expect(await screen.findByTestId(`UCSBSubjectsTable-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG");
 
-    const deleteButton = getByTestId(`UCSBSubjectsTable-cell-row-0-col-Delete-button`);
+    const deleteButton = screen.getByTestId(`UCSBSubjectsTable-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
     
     fireEvent.click(deleteButton);
 
     await waitFor(() => expect(mockedMutate).toHaveBeenCalledTimes(1));
   });
-
-
 });
-

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -1,7 +1,6 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable"
-
 
 describe("UserTable tests", () => {
 
@@ -18,7 +17,7 @@ describe("UserTable tests", () => {
     });
 
     test("Has the expected colum headers and content", () => {
-        const { getByText, getByTestId } = render(
+        render(
           <UsersTable users={usersFixtures.threeUsers}/>
         );
     
@@ -27,20 +26,18 @@ describe("UserTable tests", () => {
         const testId = "UsersTable";
 
         expectedHeaders.forEach( (headerText)=> {
-            const header = getByText(headerText);
+            const header = screen.getByText(headerText);
             expect(header).toBeInTheDocument();
         });
 
         expectedFields.forEach( (field)=> {
-          const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+          const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
           expect(header).toBeInTheDocument();
         });
 
-        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        expect(getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
-
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
       });
 });
-

--- a/frontend/src/tests/pages/AdminLoadSubjectsPage.test.js
+++ b/frontend/src/tests/pages/AdminLoadSubjectsPage.test.js
@@ -1,14 +1,13 @@
-import { fireEvent, render, waitFor} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
-
-import axios from "axios";
-import AxiosMockAdapter from "axios-mock-adapter";
+import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -21,7 +20,6 @@ jest.mock('react-toastify', () => {
 });
 
 describe("AdminLoadSubjectsPage tests", () => {
-
     const axiosMock = new AxiosMockAdapter(axios);
     const testId = "UCSBSubjectsTable";
 
@@ -31,7 +29,6 @@ describe("AdminLoadSubjectsPage tests", () => {
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
-
 
     test("renders without crashing for admin user", () => {
         setupAdminUser();
@@ -47,13 +44,12 @@ describe("AdminLoadSubjectsPage tests", () => {
         );
     });
 
-
     test("renders three earthquakes without crashing for regular user", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/UCSBSubjects/all").reply(200, ucsbSubjectsFixtures.threeSubjects);
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AdminLoadSubjectsPage />
@@ -61,20 +57,18 @@ describe("AdminLoadSubjectsPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("GER");
-        expect(getByTestId(`${testId}-cell-row-2-col-subjectCode`)).toHaveTextContent("GREEK");
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("GEOG");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("GER");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-subjectCode`)).toHaveTextContent("GREEK");
     });
 
-
-    test("test what happens when you click load, admin - originally nothing in table, load 3 subjects", async () => {
-
+    test("what happens when you click load, admin - originally nothing in table, load 3 subjects", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/UCSBSubjects/all").reply(200, []);
         axiosMock.onPost("/api/UCSBSubjects/load").reply(200, ucsbSubjectsFixtures.threeSubjects);
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AdminLoadSubjectsPage />
@@ -82,9 +76,9 @@ describe("AdminLoadSubjectsPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`AdminLoadSubjects-Load-Button`)).toBeInTheDocument(); });
+        expect(await screen.findByTestId(`AdminLoadSubjects-Load-Button`)).toBeInTheDocument();
 
-        const loadButton = getByTestId(`AdminLoadSubjects-Load-Button`);
+        const loadButton = screen.getByTestId(`AdminLoadSubjects-Load-Button`);
         expect(loadButton).toBeInTheDocument();
         fireEvent.click(loadButton);
         
@@ -92,14 +86,14 @@ describe("AdminLoadSubjectsPage tests", () => {
         expect(mockToast).toBeCalledWith("Number of Subjects Loaded : 3");
     });
 
-    test("test what happens when you click load, admin - originally 3 subjects, load nothing", async () => {
+    test("what happens when you click load, admin - originally 3 subjects, load nothing", async () => {
 
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/UCSBSubjects/all").reply(200, ucsbSubjectsFixtures.threeSubjects);
         axiosMock.onPost("/api/UCSBSubjects/load").reply(200, []);
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AdminLoadSubjectsPage />
@@ -107,16 +101,13 @@ describe("AdminLoadSubjectsPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`AdminLoadSubjects-Load-Button`)).toBeInTheDocument(); });
+        expect(await screen.findByTestId(`AdminLoadSubjects-Load-Button`)).toBeInTheDocument();
 
-        const loadButton = getByTestId(`AdminLoadSubjects-Load-Button`);
+        const loadButton = screen.getByTestId(`AdminLoadSubjects-Load-Button`);
         expect(loadButton).toBeInTheDocument();
         fireEvent.click(loadButton);
         
         await waitFor(() =>  expect(axiosMock.history.post.length).toBe(1));
         expect(mockToast).toBeCalledWith("Number of Subjects Loaded : -3");
     });
-
-    
-
 });

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -1,17 +1,16 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import AdminUsersPage from "main/pages/AdminUsersPage";
-import usersFixtures from "fixtures/usersFixtures";
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import mockConsole from "jest-mock-console";
-
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import usersFixtures from "fixtures/usersFixtures";
+import AdminUsersPage from "main/pages/AdminUsersPage";
 
 describe("AdminUsersPage tests", () => {
-
     const axiosMock = new AxiosMockAdapter(axios);
 
     const testId = "UsersTable";
@@ -27,7 +26,7 @@ describe("AdminUsersPage tests", () => {
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/admin/users").reply(200, usersFixtures.threeUsers);
 
-        const { getByText } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AdminUsersPage />
@@ -35,11 +34,7 @@ describe("AdminUsersPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByText("Users")).toBeInTheDocument());
-
-        await waitFor(() => expect(getByText("Users")).toBeInTheDocument());
-
-
+        expect(await screen.findByText("Users")).toBeInTheDocument();
     });
 
     test("renders empty table when backend unavailable", async () => {
@@ -48,7 +43,7 @@ describe("AdminUsersPage tests", () => {
 
         const restoreConsole = mockConsole();
 
-        const { queryByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <AdminUsersPage />
@@ -62,7 +57,7 @@ describe("AdminUsersPage tests", () => {
         expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
         restoreConsole();
 
-        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
 
     });
 

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -1,19 +1,15 @@
-import {
-  queryByPlaceholderText,
-  render,
-  waitFor,
-} from "@testing-library/react";
-import HomePage from "main/pages/HomePage";
-import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { allTheSubjects } from "fixtures/subjectFixtures";
-import { coursesFixtures } from "fixtures/courseFixtures";
-
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import userEvent from "@testing-library/user-event";
+
+import HomePage from "main/pages/HomePage";
+import { coursesFixtures } from "fixtures/courseFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -55,7 +51,7 @@ describe("HomePage tests", () => {
       .onGet("/api/public/basicsearch")
       .reply(200, { classes: coursesFixtures.oneCourse });
 
-    const { getAllByText, getByText, getByLabelText } = render(
+    render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <HomePage />
@@ -63,17 +59,17 @@ describe("HomePage tests", () => {
       </QueryClientProvider>
     );
 
-    const selectQuarter = getByLabelText("Quarter");
+    const selectQuarter = screen.getByLabelText("Quarter");
     userEvent.selectOptions(selectQuarter, "20211");
-    const selectSubject = getByLabelText("Subject Area");
-    await waitFor(() => {
-      expect(getByLabelText("Subject Area")).toHaveTextContent("ANTH");
-    });
+    const selectSubject = screen.getByLabelText("Subject Area");
+
+    expect(await screen.findByLabelText("Subject Area")).toHaveTextContent("ANTH");
+
     userEvent.selectOptions(selectSubject, "ANTH");
-    const selectLevel = getByLabelText("Course Level");
+    const selectLevel = screen.getByLabelText("Course Level");
     userEvent.selectOptions(selectLevel, "G");
 
-    const submitButton = getByText("Submit");
+    const submitButton = screen.getByText("Submit");
     expect(submitButton).toBeInTheDocument();
     userEvent.click(submitButton);
 
@@ -89,6 +85,6 @@ describe("HomePage tests", () => {
       level: "G",
     });
 
-    expect(getByText("CMPSC")).toBeInTheDocument();
+    expect(screen.getByText("CMPSC")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -76,7 +76,7 @@ describe("HomePage tests", () => {
     axiosMock.resetHistory();
 
     await waitFor(() => {
-      expect(axiosMock.onGet("/api/public/basicsearch"));
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
     });
 
     expect(axiosMock.history.get[0].params).toEqual({

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import PersonalSchedulesCreatePage from "main/pages/PersonalSchedules/PersonalSchedulesCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -62,7 +62,7 @@ describe("PersonalSchedulesCreatePage tests", () => {
 
         axiosMock.onPost("/api/personalschedules/post").reply( 202, personalSchedule );
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <PersonalSchedulesCreatePage />
@@ -70,16 +70,14 @@ describe("PersonalSchedulesCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => {
-            expect(getByTestId("PersonalScheduleForm-name")).toBeInTheDocument();
-        });
+        expect(await screen.findByTestId("PersonalScheduleForm-name")).toBeInTheDocument();
         
-        const nameField = getByTestId("PersonalScheduleForm-name");
-        const descriptionField = getByTestId("PersonalScheduleForm-description");
+        const nameField = screen.getByTestId("PersonalScheduleForm-name");
+        const descriptionField = screen.getByTestId("PersonalScheduleForm-description");
         //const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
         const quarterField = document.querySelector("#PersonalScheduleForm-quarter");
         //const selectQuarter = getByLabelText("Quarter")
-        const submitButton = getByTestId("PersonalScheduleForm-submit");
+        const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
         fireEvent.change(nameField, { target: { value: 'SampName' } });
         fireEvent.change(descriptionField, { target: { value: 'desc' } });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
@@ -1,16 +1,14 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import PersonalSchedulesIndexPage from "main/pages/PersonalSchedules/PersonalSchedulesIndexPage";
-
-
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
 
+import PersonalSchedulesIndexPage from "main/pages/PersonalSchedules/PersonalSchedulesIndexPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -79,7 +77,7 @@ describe("PersonalSchedulesIndexPage tests", () => {
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/personalschedules/all").reply(200, personalScheduleFixtures.threePersonalSchedules);
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <PersonalSchedulesIndexPage />
@@ -87,9 +85,9 @@ describe("PersonalSchedulesIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
     });
 
@@ -98,7 +96,7 @@ describe("PersonalSchedulesIndexPage tests", () => {
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/personalschedules/all").reply(200, personalScheduleFixtures.threePersonalSchedules);
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <PersonalSchedulesIndexPage />
@@ -106,9 +104,9 @@ describe("PersonalSchedulesIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
     });
 
@@ -120,7 +118,7 @@ describe("PersonalSchedulesIndexPage tests", () => {
 
         const restoreConsole = mockConsole();
 
-        const { queryByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <PersonalSchedulesIndexPage />
@@ -134,20 +132,18 @@ describe("PersonalSchedulesIndexPage tests", () => {
         expect(errorMessage).toMatch("Error communicating with backend via GET on /api/personalschedules/all");
         restoreConsole();
 
-        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
     });
 
 
     // to be uncommented when Delete is implemented
-    test("test what happens when you click delete, admin", async () => {
-
-
+    test("what happens when you click delete, admin", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/personalschedules/all").reply(200, personalScheduleFixtures.threePersonalSchedules);
         axiosMock.onDelete("/api/personalschedules").reply(200, "PersonalSchedule with id 1 was deleted");
 
-        const { getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <PersonalSchedulesIndexPage />
@@ -155,18 +151,16 @@ describe("PersonalSchedulesIndexPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
-        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
-
-        const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
 
         fireEvent.click(deleteButton);
 
         await waitFor(() => { expect(mockToast).toBeCalledWith("PersonalSchedule with id 1 was deleted") });
-
     });
 
 });

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
@@ -9,7 +9,6 @@ import ProfilePage from "main/pages/ProfilePage";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 describe("ProfilePage tests", () => {
-
     const queryClient = new QueryClient();
 
     test("renders correctly for regular logged in user", async () => {
@@ -18,7 +17,7 @@ describe("ProfilePage tests", () => {
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-        const { getByText } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <ProfilePage />
@@ -26,8 +25,8 @@ describe("ProfilePage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor( () => expect(getByText("Phillip Conrad")).toBeInTheDocument() );
-        expect(getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
+        expect(await screen.findByText("Phillip Conrad")).toBeInTheDocument();
+        expect(screen.getByText("pconrad.cis@gmail.com")).toBeInTheDocument();
     });
 
     test("renders correctly for admin user", async () => {
@@ -36,7 +35,7 @@ describe("ProfilePage tests", () => {
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-        const { getByText, getByTestId } = render(
+        render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
                     <ProfilePage />
@@ -44,11 +43,11 @@ describe("ProfilePage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor( () => expect(getByText("Phill Conrad")).toBeInTheDocument() );
-        expect(getByText("phtcon@ucsb.edu")).toBeInTheDocument();
-        expect(getByTestId("role-badge-user")).toBeInTheDocument();
-        expect(getByTestId("role-badge-admin")).toBeInTheDocument();
-        expect(getByTestId("role-badge-member")).toBeInTheDocument();
+        expect(await screen.findByText("Phill Conrad")).toBeInTheDocument();
+        expect(screen.getByText("phtcon@ucsb.edu")).toBeInTheDocument();
+        expect(screen.getByTestId("role-badge-user")).toBeInTheDocument();
+        expect(screen.getByTestId("role-badge-admin")).toBeInTheDocument();
+        expect(screen.getByTestId("role-badge-member")).toBeInTheDocument();
     });
 });
 

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -15,7 +15,7 @@ const { MemoryRouter } = jest.requireActual('react-router-dom');
 
 describe("utils/currentUser tests", () => {
     describe("useCurrentUser tests", () => {
-        test("test useCurrentUser retrieves initial data ", async () => {
+        test("useCurrentUser retrieves initial data", async () => {
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (
                 <QueryClientProvider client={queryClient}>
@@ -45,7 +45,7 @@ describe("utils/currentUser tests", () => {
             restoreConsole();
         });
 
-        test("test useCurrentUser retrieves data from API ", async () => {
+        test("useCurrentUser retrieves data from API", async () => {
 
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (
@@ -68,7 +68,7 @@ describe("utils/currentUser tests", () => {
 
         });
 
-        test("test useCurrentUser when API unreachable ", async () => {
+        test("useCurrentUser when API unreachable", async () => {
 
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (
@@ -93,7 +93,7 @@ describe("utils/currentUser tests", () => {
             queryClient.clear();
         });
 
-        test("test useCurrentUser handles missing roles correctly ", async () => {
+        test("useCurrentUser handles missing roles correctly", async () => {
 
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (
@@ -122,7 +122,7 @@ describe("utils/currentUser tests", () => {
 
     });
     describe("useLogout tests", () => {
-        test("useLogout  ", async () => {
+        test("useLogout", async () => {
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (
                 <QueryClientProvider client={queryClient}>
@@ -164,7 +164,7 @@ describe("utils/currentUser tests", () => {
             expect(hasRole({ loggedIn: true, root: { rolesList: null } }, "ROLE_ADMIN")).toBeFalsy();
         });
 
-        test('test some code paths when data is in currentUser', async () => {
+        test('some code paths when data is in currentUser', async () => {
             expect(hasRole({ data: {} }, "ROLE_ADMIN")).toBeFalsy();
             expect(hasRole({ data: {root: null }}, "ROLE_ADMIN")).toBeFalsy();
             expect(hasRole({ data: {root: {} }}, "ROLE_ADMIN")).toBeFalsy();

--- a/frontend/src/tests/utils/sortHelper.test.js
+++ b/frontend/src/tests/utils/sortHelper.test.js
@@ -24,7 +24,7 @@ describe("sortHelper tests", () => {
     expect(singers).toEqual( [carpenter, cobain, tyler, nicks] )
   });
 
-  test("should sort by name", async () => {
+  test("should sort by name ascending", async () => {
     singers.sort(compareValues('name', 'asc'));
     expect(singers).toEqual( [carpenter, cobain, tyler, nicks] )
   });

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -12,7 +12,7 @@ const { _MemoryRouter } = jest.requireActual('react-router-dom');
 
 describe("utils/systemInfo tests", () => {
     describe("useSystemInfo tests", () => {
-        test("test useSystemInfo retrieves initial data ", async () => {
+        test("useSystemInfo retrieves initial data", async () => {
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (
                 <QueryClientProvider client={queryClient}>
@@ -48,7 +48,7 @@ describe("utils/systemInfo tests", () => {
             restoreConsole();
         });
 
-        test("test useSystemInfo retrieves data from API ", async () => {
+        test("useSystemInfo retrieves data from API", async () => {
 
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (
@@ -70,7 +70,7 @@ describe("utils/systemInfo tests", () => {
 
         });
 
-        test("test systemInfo when API unreachable ", async () => {
+        test("systemInfo when API unreachable", async () => {
 
             const queryClient = new QueryClient();
             const wrapper = ({ children }) => (

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -1,11 +1,10 @@
 import { QueryClient, QueryClientProvider } from "react-query";
-import { renderHook, act } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react-hooks'
 import mockConsole from "jest-mock-console";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
-
+import { useBackend } from "main/utils/useBackend";
 
 jest.mock('react-router-dom');
 
@@ -29,7 +28,7 @@ describe("utils/useBackend tests", () => {
         axiosMock.resetHistory();
     });
 
-    test("test useBackend handles 404 error correctly", async () => {
+    test("useBackend handles 404 error correctly", async () => {
         const restoreConsole = mockConsole();
 
         // See: https://react-query.tanstack.com/guides/testing#turn-off-retries

--- a/frontend/src/tests/utils/useBackendMutationFailure.test.js
+++ b/frontend/src/tests/utils/useBackendMutationFailure.test.js
@@ -1,10 +1,10 @@
 import { QueryClient, QueryClientProvider } from "react-query";
-import { renderHook, act } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react-hooks'
 import mockConsole from "jest-mock-console";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useBackendMutation } from "main/utils/useBackend";
 
 
 jest.mock('react-router-dom');
@@ -31,7 +31,7 @@ describe("utils/useBackend tests", () => {
             axiosMock.resetHistory();
         });
 
-        test("test useBackendMutation handles error correctly", async () => {
+        test("useBackendMutation handles error correctly", async () => {
 
             const restoreConsole = mockConsole();
 

--- a/frontend/src/tests/utils/useBackendMutationSuccess.test.js
+++ b/frontend/src/tests/utils/useBackendMutationSuccess.test.js
@@ -4,7 +4,7 @@ import mockConsole from "jest-mock-console";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useBackendMutation } from "main/utils/useBackend";
 
 
 jest.mock('react-router-dom');
@@ -30,7 +30,7 @@ describe("utils/useBackend tests", () => {
             axiosMock.resetHistory();
         });
 
-        test("test useBackendMutation handles success correctly", async () => {
+        test("useBackendMutation handles success correctly", async () => {
             const restoreConsole = mockConsole();
 
             // See: https://react-query.tanstack.com/guides/testing#turn-off-retries

--- a/pom.xml
+++ b/pom.xml
@@ -243,8 +243,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v12.12.0</nodeVersion>
-                                    <npmVersion>6.14.3</npmVersion>
+                                    <nodeVersion>v16.15.0</nodeVersion>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
# Overview

This PR adds ESLint into the codebase and resolves any existing ESLint errors (there were a lot!). 

Specifically:
* The ESLint dependencies and `.eslintrc.json` file was added (adapted from ucsb-cs156/demo-spring-react-example)
* The ESLint GitHub Actions workflow was added, and all other GitHub Actions workflow were modified to match demo-spring-react-example
* `pom.xml` has been updated to use the latest version of Node 16
* All linting errors have been fixed (all ~300 of them)
  * Well, most of them. I temporarily turned off one rule (`testing-library/no-node-access`) because I was unable to find a good replacement for the errors in a reasonable time. I'll revisit this one later.