### PR TITLE
Pc add document classes

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConvertedSection {
+    CourseInfo courseInfo;
+    Section section;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/ConvertedSection.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ConvertedSection {
-    CourseInfo courseInfo;
-    Section section;
+    private CourseInfo courseInfo;
+    private Section section;
 }

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.courses.documents;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "courses")
+public class Course {
+    private String quarter;
+    private String courseId;
+    private String title;
+    private String description;
+    private List<Section> classSections;
+    private List<GeneralEducation> generalEducation;
+    private FinalExam finalExam;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CourseInfo.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * CourseInfo is an object that stores all of the information about a
+ * course from the UCSB Courses API except for the section info
+ */
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseInfo {
+    private String quarter;
+    private String courseId;
+    private String title;
+    private String description;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
@@ -22,7 +22,7 @@ public class CoursePage {
     private int pageNumber;
     private int pageSize;
     private int total;
-    List<Course> classes;
+    private List<Course> classes;
 
     /**
      * Create a CoursePage object from json representation

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
@@ -1,0 +1,79 @@
+package edu.ucsb.cs156.courses.documents;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Slf4j
+public class CoursePage {
+    private int pageNumber;
+    private int pageSize;
+    private int total;
+    List<Course> classes;
+
+    /**
+     * Create a CoursePage object from json representation
+     * 
+     * @param json String of json returned by API endpoint {@code /classes/search}
+     * @return a new CoursePage object
+     * @see <a href=
+     *      "https://developer.ucsb.edu/content/academic-curriculums">https://developer.ucsb.edu/content/academic-curriculums</a>
+     */
+    public static CoursePage fromJSON(String json) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+            CoursePage coursePage = objectMapper.readValue(json, CoursePage.class);
+            return coursePage;
+        } catch (JsonProcessingException jpe) {
+            log.error("JsonProcessingException:" + jpe);
+            return null;
+        }
+    }
+
+    /**
+     * Create a List<ConvertedSection> from json representation
+     * 
+     * @param json String of json returned by API endpoint {@code /classes/search}
+     * @return a new CoursePage object
+     * @see <a href=
+     *      "https://developer.ucsb.edu/content/academic-curriculums">https://developer.ucsb.edu/content/academic-curriculums</a>
+     */
+    public List<ConvertedSection> convertedSections() {
+
+        List<ConvertedSection> result = new ArrayList<ConvertedSection>();
+
+        for (Course c : this.getClasses()) {
+            for (Section section : c.getClassSections()) {
+                CourseInfo courseInfo = CourseInfo.builder()
+                        .quarter(c.getQuarter())
+                        .courseId(c.getCourseId())
+                        .title(c.getTitle())
+                        .description(c.getDescription())
+                        .build();
+                ConvertedSection cs = ConvertedSection.builder()
+                        .courseInfo(courseInfo)
+                        .section(section)
+                        .build();
+                result.add(cs);
+
+            }
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/FinalExam.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/FinalExam.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinalExam {
+    private boolean hasFinals;
+    private String comments;
+    private String examDay;
+    private String examDate;
+    private String beginTime;
+    private String endTime;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/GeneralEducation.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/GeneralEducation.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeneralEducation {
+    private String geCode;
+    private String geCollege;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Instructor.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Instructor.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Instructor {
+    private String instructor;
+    private String functionCode;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Section.java
@@ -1,0 +1,76 @@
+package edu.ucsb.cs156.courses.documents;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Section {
+
+    /** a unique number assigned to a section */
+    private String enrollCode;
+    /** section number of the course */
+    private String section;
+    /** session only for summer quarter */
+    private String session;
+    /** if the class is closed */
+    private String classClosed;
+    /** is course cancelled */
+    private String courseCancelled;
+    /**
+     * Grading Options Code like Pass/No Pass (P/NP) Or Letter Grades (L).
+     * 
+     * @see <a href=
+     *      "https://developer.ucsb.edu/content/student-record-code-lookups">
+     *      https://developer.ucsb.edu/content/student-record-code-lookups</a>
+     * 
+     */
+    private String gradingOptionCode;
+
+    /** total number of enrollments in the course */
+    private Integer enrolledTotal;
+    /** max number of students can be enrolled in the section */
+    private Integer maxEnroll;
+
+    /** Secondary Status of the course */
+    private String secondaryStatus;
+
+    /** Is department approval required for enrollment in the section */
+    private boolean departmentApprovalRequired;
+
+    /** Is instructor approval required for enrollment in the section */
+    private boolean instructorApprovalRequired;
+
+    /** Is there restriction on the level of the course */
+    private String restrictionLevel;
+
+    /** Is there restriction on the major of the student */
+    private String restrictionMajor;
+
+    /** Is there restriction on the major and pass time of the student */
+    private String restrictionMajorPass;
+
+    /** Is there restriction on the minor of the student */
+    private String restrictionMinor;
+
+    /** Is there restriction on the minor and pass time of the student */
+    private String restrictionMinorPass;
+
+    /** Concurrent courses for the section */
+    private List<String> concurrentCourses;
+
+    /**
+     * List of {@link TimeLocation} objects for this course
+     */
+    private List<TimeLocation> timeLocations;
+    /**
+     * List of {@link Instructor} objects for this course
+     */
+    private List<Instructor> instructors;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/TimeLocation.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/TimeLocation.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.courses.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeLocation {
+    private String room;
+    private String building;
+    private String roomCapacity;
+    private String days; 
+    private String beginTime; 
+    private String endTime;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/entities/PersonalSchedule.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/PersonalSchedule.java
@@ -7,15 +7,16 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 @Entity(name = "personalschedule")
 public class PersonalSchedule {
   @Id

--- a/src/main/java/edu/ucsb/cs156/courses/entities/UCSBSubject.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/UCSBSubject.java
@@ -5,15 +5,16 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.GeneratedValue;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
 @Entity(name = "ucsb_subjects")
 public class UCSBSubject {
     @Id

--- a/src/main/java/edu/ucsb/cs156/courses/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/User.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.entities;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
@@ -11,9 +12,9 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 @Entity(name = "users")
 public class User {
   @Id

--- a/src/main/java/edu/ucsb/cs156/courses/models/CurrentUser.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/CurrentUser.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.models;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -13,9 +14,9 @@ import edu.ucsb.cs156.courses.entities.User;
 import java.util.Collection;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 public class CurrentUser {
   private User user;
   private Collection<? extends GrantedAuthority> roles;

--- a/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/SystemInfo.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.courses.models;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -8,9 +9,9 @@ import lombok.AccessLevel;
 
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -1,9 +1,15 @@
 package edu.ucsb.cs156.courses.services;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -16,11 +22,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.Course;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.Section;
+
 /**
  * Service object that wraps the UCSB Academic Curriculum API
  */
 @Service
-public class UCSBCurriculumService  {
+public class UCSBCurriculumService {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private Logger logger = LoggerFactory.getLogger(UCSBCurriculumService.class);
 
@@ -62,8 +77,8 @@ public class UCSBCurriculumService  {
         logger.info("url=" + url);
 
         String retVal = "";
-        MediaType contentType=null;
-        HttpStatus statusCode=null;
+        MediaType contentType = null;
+        HttpStatus statusCode = null;
         try {
             ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
             contentType = re.getHeaders().getContentType();
@@ -72,8 +87,16 @@ public class UCSBCurriculumService  {
         } catch (HttpClientErrorException e) {
             retVal = "{\"error\": \"401: Unauthorized\"}";
         }
-        logger.info("json: {} contentType: {} statusCode: {}",retVal,contentType,statusCode);
+        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
+    }
+
+    public List<ConvertedSection> getConvertedSections(String subjectArea, String quarter, String courseLevel)
+            throws JsonProcessingException {
+        String json = getJSON(subjectArea, quarter, courseLevel);
+        CoursePage coursePage = objectMapper.readValue(json, CoursePage.class);
+        List<ConvertedSection> result = coursePage.convertedSections();       
+        return result;
     }
 
     public String getSubjectsJSON() {
@@ -89,8 +112,8 @@ public class UCSBCurriculumService  {
         logger.info("url=" + SUBJECTS_ENDPOINT);
 
         String retVal = "";
-        MediaType contentType=null;
-        HttpStatus statusCode=null;
+        MediaType contentType = null;
+        HttpStatus statusCode = null;
         try {
             ResponseEntity<String> re = restTemplate.exchange(SUBJECTS_ENDPOINT, HttpMethod.GET, entity, String.class);
             contentType = re.getHeaders().getContentType();
@@ -99,8 +122,8 @@ public class UCSBCurriculumService  {
         } catch (HttpClientErrorException e) {
             retVal = "{\"error\": \"401: Unauthorized\"}";
         }
-        logger.info("json: {} contentType: {} statusCode: {}",retVal,contentType,statusCode);
+        logger.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
         return retVal;
     }
-    
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageFixtures.java
@@ -1,0 +1,2973 @@
+package edu.ucsb.cs156.courses.documents;
+
+public class CoursePageFixtures {
+
+    public static final String COURSE_PAGE_JSON_MATH3B = """
+                   {
+                       "pageNumber": 1,
+                       "pageSize": 10,
+                       "total": 1,
+                       "classes": [
+                         {
+                           "quarter": "20222",
+                           "courseId": "MATH      3B ",
+                           "title": "CALC WITH APPLI 2",
+                           "contactHours": 30,
+                           "description": "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics.",
+                           "college": "L&S",
+                           "objLevelCode": "U",
+                           "subjectArea": "MATH    ",
+                           "unitsFixed": 4,
+                           "unitsVariableHigh": null,
+                           "unitsVariableLow": null,
+                           "delayedSectioning": null,
+                           "inProgressCourse": null,
+                           "gradingOption": null,
+                           "instructionType": "LEC",
+                           "onLineCourse": false,
+                           "deptCode": "MATH ",
+                           "generalEducation": [
+                             {
+                               "geCode": "C  ",
+                               "geCollege": "L&S "
+                             },
+                             {
+                               "geCode": "QNT",
+                               "geCollege": "L&S "
+                             }
+                           ],
+                           "classSections": [
+                             {
+                               "enrollCode": "30395",
+                               "section": "0100",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 142,
+                               "maxEnroll": 150,
+                               "secondaryStatus": "R",
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1001",
+                                   "building": "LSB",
+                                   "roomCapacity": 159,
+                                   "days": "M W F  ",
+                                   "beginTime": "11:00",
+                                   "endTime": "11:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "KUMAR S L",
+                                   "functionCode": "Teaching and in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "30403",
+                               "section": "0101",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 23,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1231",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": " T     ",
+                                   "beginTime": "17:00",
+                                   "endTime": "17:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "YOUNG C G",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "30411",
+                               "section": "0102",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 25,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1231",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": " T     ",
+                                   "beginTime": "18:00",
+                                   "endTime": "18:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "YOUNG C G",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "30429",
+                               "section": "0103",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 23,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1207",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "   R   ",
+                                   "beginTime": "08:00",
+                                   "endTime": "08:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "FAGAN L M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "30437",
+                               "section": "0104",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 24,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "2251",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "   R   ",
+                                   "beginTime": "17:00",
+                                   "endTime": "17:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "YOUNG C G",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "30445",
+                               "section": "0105",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 24,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1214",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "   R   ",
+                                   "beginTime": "19:00",
+                                   "endTime": "19:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "YOUNG C G",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "30452",
+                               "section": "0106",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 23,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1215",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": " T     ",
+                                   "beginTime": "08:00",
+                                   "endTime": "08:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "FAGAN L M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "54692",
+                               "section": "0200",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 41,
+                               "maxEnroll": 150,
+                               "secondaryStatus": "R",
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1001",
+                                   "building": "LSB",
+                                   "roomCapacity": 159,
+                                   "days": " T R   ",
+                                   "beginTime": "12:30",
+                                   "endTime": "13:45"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "PARK J",
+                                   "functionCode": "Teaching and in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "54700",
+                               "section": "0201",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 7,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1215",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "M      ",
+                                   "beginTime": "08:00",
+                                   "endTime": "08:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "PARKER M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "54783",
+                               "section": "0202",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 8,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1231",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "M      ",
+                                   "beginTime": "18:00",
+                                   "endTime": "18:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "PARKER M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "54791",
+                               "section": "0203",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 19,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1237",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "M      ",
+                                   "beginTime": "17:00",
+                                   "endTime": "17:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "PARKER M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "54809",
+                               "section": "0204",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 1,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1228",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "M      ",
+                                   "beginTime": "18:00",
+                                   "endTime": "18:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "FAGAN L M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "54817",
+                               "section": "0205",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 2,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1214",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "M      ",
+                                   "beginTime": "19:00",
+                                   "endTime": "19:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "PARKER M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             },
+                             {
+                               "enrollCode": "54825",
+                               "section": "0206",
+                               "session": null,
+                               "classClosed": null,
+                               "courseCancelled": null,
+                               "gradingOptionCode": null,
+                               "enrolledTotal": 4,
+                               "maxEnroll": 25,
+                               "secondaryStatus": null,
+                               "departmentApprovalRequired": false,
+                               "instructorApprovalRequired": false,
+                               "restrictionLevel": "K",
+                               "restrictionMajor": "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+                               "restrictionMajorPass": "1",
+                               "restrictionMinor": null,
+                               "restrictionMinorPass": null,
+                               "concurrentCourses": [],
+                               "timeLocations": [
+                                 {
+                                   "room": "1236",
+                                   "building": "HSSB",
+                                   "roomCapacity": 26,
+                                   "days": "M      ",
+                                   "beginTime": "17:00",
+                                   "endTime": "17:50"
+                                 }
+                               ],
+                               "instructors": [
+                                 {
+                                   "instructor": "FAGAN L M",
+                                   "functionCode": "Teaching but not in charge"
+                                 }
+                               ]
+                             }
+                           ]
+                         }
+                       ]
+                     }
+            """;
+
+    public static final String CONVERTED_SECTIONS_JSON_MATH5B = """
+        [ {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "30395",
+              "section" : "0100",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 142,
+              "maxEnroll" : 150,
+              "secondaryStatus" : "R",
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1001",
+                "building" : "LSB",
+                "roomCapacity" : "159",
+                "days" : "M W F  ",
+                "beginTime" : "11:00",
+                "endTime" : "11:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "KUMAR S L",
+                "functionCode" : "Teaching and in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "30403",
+              "section" : "0101",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 23,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1231",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : " T     ",
+                "beginTime" : "17:00",
+                "endTime" : "17:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "YOUNG C G",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "30411",
+              "section" : "0102",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 25,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1231",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : " T     ",
+                "beginTime" : "18:00",
+                "endTime" : "18:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "YOUNG C G",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "30429",
+              "section" : "0103",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 23,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1207",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "   R   ",
+                "beginTime" : "08:00",
+                "endTime" : "08:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "FAGAN L M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "30437",
+              "section" : "0104",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 24,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "2251",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "   R   ",
+                "beginTime" : "17:00",
+                "endTime" : "17:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "YOUNG C G",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "30445",
+              "section" : "0105",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 24,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1214",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "   R   ",
+                "beginTime" : "19:00",
+                "endTime" : "19:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "YOUNG C G",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "30452",
+              "section" : "0106",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 23,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1215",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : " T     ",
+                "beginTime" : "08:00",
+                "endTime" : "08:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "FAGAN L M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "54692",
+              "section" : "0200",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 41,
+              "maxEnroll" : 150,
+              "secondaryStatus" : "R",
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1001",
+                "building" : "LSB",
+                "roomCapacity" : "159",
+                "days" : " T R   ",
+                "beginTime" : "12:30",
+                "endTime" : "13:45"
+              } ],
+              "instructors" : [ {
+                "instructor" : "PARK J",
+                "functionCode" : "Teaching and in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "54700",
+              "section" : "0201",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 7,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1215",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "M      ",
+                "beginTime" : "08:00",
+                "endTime" : "08:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "PARKER M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "54783",
+              "section" : "0202",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 8,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1231",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "M      ",
+                "beginTime" : "18:00",
+                "endTime" : "18:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "PARKER M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "54791",
+              "section" : "0203",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 19,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1237",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "M      ",
+                "beginTime" : "17:00",
+                "endTime" : "17:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "PARKER M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "54809",
+              "section" : "0204",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 1,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1228",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "M      ",
+                "beginTime" : "18:00",
+                "endTime" : "18:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "FAGAN L M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "54817",
+              "section" : "0205",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 2,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1214",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "M      ",
+                "beginTime" : "19:00",
+                "endTime" : "19:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "PARKER M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          }, {
+            "courseInfo" : {
+              "quarter" : "20222",
+              "courseId" : "MATH      3B ",
+              "title" : "CALC WITH APPLI 2",
+              "description" : "Integral calculus including definite and indefinite integrals, techniques o f integration; introduction to sequences and series; with applications in m athematics and physics."
+            },
+            "section" : {
+              "enrollCode" : "54825",
+              "section" : "0206",
+              "session" : null,
+              "classClosed" : null,
+              "courseCancelled" : null,
+              "gradingOptionCode" : null,
+              "enrolledTotal" : 4,
+              "maxEnroll" : 25,
+              "secondaryStatus" : null,
+              "departmentApprovalRequired" : false,
+              "instructorApprovalRequired" : false,
+              "restrictionLevel" : "K",
+              "restrictionMajor" : "&MATH &STATS&CNENG&CMPSC&ECE  &ME   &CRSTU&PHYS",
+              "restrictionMajorPass" : "1",
+              "restrictionMinor" : null,
+              "restrictionMinorPass" : null,
+              "concurrentCourses" : [ ],
+              "timeLocations" : [ {
+                "room" : "1236",
+                "building" : "HSSB",
+                "roomCapacity" : "26",
+                "days" : "M      ",
+                "beginTime" : "17:00",
+                "endTime" : "17:50"
+              } ],
+              "instructors" : [ {
+                "instructor" : "FAGAN L M",
+                "functionCode" : "Teaching but not in charge"
+              } ]
+            }
+          } ]          
+            """;
+
+    public static final String COURSE_PAGE_JSON = """
+
+            {
+                "pageNumber": 1,
+                "pageSize": 10,
+                "total": 49,
+                "classes": [
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC     5A ",
+                    "title": "INTRO DATA SCI 1",
+                    "contactHours": 30,
+                    "description": "Introduction to data science methods and Python programming language for st udents with little to no experience in the subjects. Topics include foundat ional programming concepts, problem-solving strategies and code design, and data science concepts as table operations, exploratory data analysis, basi c probability.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "59600",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 85,
+                        "maxEnroll": 90,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "2617",
+                            "building": "ELLSN",
+                            "roomCapacity": 90,
+                            "days": " T R   ",
+                            "beginTime": "17:00",
+                            "endTime": "18:15"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "SOLIS S W",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59618",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 27,
+                        "maxEnroll": 30,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1530",
+                            "building": "PHELP",
+                            "roomCapacity": 30,
+                            "days": "  W    ",
+                            "beginTime": "10:00",
+                            "endTime": "10:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "BATTULA N",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59626",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 29,
+                        "maxEnroll": 30,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1530",
+                            "building": "PHELP",
+                            "roomCapacity": 30,
+                            "days": "  W    ",
+                            "beginTime": "11:00",
+                            "endTime": "11:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "YANG X",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59634",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 29,
+                        "maxEnroll": 30,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1530",
+                            "building": "PHELP",
+                            "roomCapacity": 30,
+                            "days": "  W    ",
+                            "beginTime": "14:00",
+                            "endTime": "14:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "TANNA A A",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC     5B ",
+                    "title": "INTRO DATA SCI 2",
+                    "contactHours": 30,
+                    "description": "Students explore the data science lifecycle, including question formulation , data collection and cleaning, exploratory data analysis and visualization , statistical inference and prediction, and decision-making. The course foc us is on transforming and analyzing data; machine learning methods includin g regression, classification and clustering; principles behind data visuali zations; concepts of measurement error and prediction; and techniques for s calable data processing.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "59642",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 33,
+                        "maxEnroll": 76,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1431",
+                            "building": "SH",
+                            "roomCapacity": 76,
+                            "days": " T R   ",
+                            "beginTime": "12:30",
+                            "endTime": "13:45"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "SOLIS S W",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59659",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 17,
+                        "maxEnroll": 25,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1007",
+                            "building": "SSMS",
+                            "roomCapacity": 25,
+                            "days": "  W    ",
+                            "beginTime": "13:00",
+                            "endTime": "13:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "LU Y",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59667",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 15,
+                        "maxEnroll": 25,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1007",
+                            "building": "SSMS",
+                            "roomCapacity": 25,
+                            "days": "  W    ",
+                            "beginTime": "14:00",
+                            "endTime": "14:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "AVARADDY N S",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59675",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 1,
+                        "maxEnroll": null,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "-CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1007",
+                            "building": "SSMS",
+                            "roomCapacity": 25,
+                            "days": "  W    ",
+                            "beginTime": "15:00",
+                            "endTime": "15:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "AVARADDY N S",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "LU Y",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC     9  ",
+                    "title": "INTERMEDIATE PYTHON",
+                    "contactHours": 30,
+                    "description": "Intermediate topics in Computer Science using the Python programming langua ge. Topics include object oriented programming, runtime analysis, data stru ctures, and software testing methodologies.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "07815",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 168,
+                        "maxEnroll": 175,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "&STATS",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1004",
+                            "building": "GIRV",
+                            "roomCapacity": 206,
+                            "days": " T R   ",
+                            "beginTime": "08:00",
+                            "endTime": "09:15"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "WANG R K",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07823",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 30,
+                        "maxEnroll": 30,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "&STATS",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "  W    ",
+                            "beginTime": "09:00",
+                            "endTime": "09:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "QIN X",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07831",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 29,
+                        "maxEnroll": 29,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "&STATS",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "  W    ",
+                            "beginTime": "10:00",
+                            "endTime": "10:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "QIN X",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "MUNDEWADI G P",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07849",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 27,
+                        "maxEnroll": 29,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "&STATS",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "  W    ",
+                            "beginTime": "11:00",
+                            "endTime": "11:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "CHENG L",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07856",
+                        "section": "0104",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 27,
+                        "maxEnroll": 29,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "&STATS",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "  W    ",
+                            "beginTime": "12:00",
+                            "endTime": "12:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "CHENG L",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "KHAN P",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59584",
+                        "section": "0105",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 27,
+                        "maxEnroll": 29,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "&STATS",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "  W    ",
+                            "beginTime": "13:00",
+                            "endTime": "13:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ELSAYED S H",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "KHAN P",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59758",
+                        "section": "0106",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 28,
+                        "maxEnroll": 29,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "&STATS",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "  W    ",
+                            "beginTime": "14:00",
+                            "endTime": "14:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ELSAYED S H",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC    24  ",
+                    "title": "PROBLEM SOLVING II",
+                    "contactHours": 30,
+                    "description": "Intermediate building blocks for solving problems using computers. Topics i nclude intermediate object-oriented programming, data structures, object-or iented design, algorithms for manipulating these data structures and their run-time analyses. Data structures introduced include stacks, queues, lists , trees, and sets.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "07864",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 118,
+                        "maxEnroll": 131,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1920",
+                            "building": "BUCHN",
+                            "roomCapacity": 147,
+                            "days": "M W    ",
+                            "beginTime": "14:00",
+                            "endTime": "15:15"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "MIRZA D",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07872",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 27,
+                        "maxEnroll": 33,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "   R   ",
+                            "beginTime": "09:00",
+                            "endTime": "09:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "SANKARAN G",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "NGUYEN L T",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07880",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 31,
+                        "maxEnroll": 33,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "   R   ",
+                            "beginTime": "10:00",
+                            "endTime": "10:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "SANKARAN G",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "NGUYEN L T",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59709",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 32,
+                        "maxEnroll": 33,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "   R   ",
+                            "beginTime": "11:00",
+                            "endTime": "11:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "AGUILERA R",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "59717",
+                        "section": "0104",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 28,
+                        "maxEnroll": 32,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "   R   ",
+                            "beginTime": "12:00",
+                            "endTime": "12:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "AGUILERA R",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "JAKALANNANAVA",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC    32  ",
+                    "title": "OBJ ORIENT DESIGN",
+                    "contactHours": 30,
+                    "description": "Advanced topics in object-oriented computing.  Topics include encapsulation,   data hiding, inheritance, polymorphism, compilation, linking and loading,   memory management, and debugging; recent advances in design and   development tools, practices, libraries, and operating system support.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "07898",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 122,
+                        "maxEnroll": 125,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "THEA2",
+                            "building": "IV",
+                            "roomCapacity": 145,
+                            "days": "M W    ",
+                            "beginTime": "12:30",
+                            "endTime": "13:45"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "MATNI Z A",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07906",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 29,
+                        "maxEnroll": 32,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "09:00",
+                            "endTime": "09:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "MISHRA R",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07914",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 31,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "10:00",
+                            "endTime": "10:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ZHANG B",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07922",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 31,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "11:00",
+                            "endTime": "11:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "VELLORE BAABU",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60186",
+                        "section": "0104",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 31,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "12:00",
+                            "endTime": "12:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "RODDICK A M",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60194",
+                        "section": "0200",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 83,
+                        "maxEnroll": 125,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1006",
+                            "building": "NH",
+                            "roomCapacity": 132,
+                            "days": "M W    ",
+                            "beginTime": "12:30",
+                            "endTime": "13:45"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "EMRE M",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60202",
+                        "section": "0201",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 27,
+                        "maxEnroll": 32,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "13:00",
+                            "endTime": "13:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "RELIC L",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "ZHU J",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60210",
+                        "section": "0202",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 30,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "14:00",
+                            "endTime": "14:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "RELIC L",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "ZHU J",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60228",
+                        "section": "0203",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 6,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "15:00",
+                            "endTime": "15:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ROSS V E",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60236",
+                        "section": "0204",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 20,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": " T     ",
+                            "beginTime": "16:00",
+                            "endTime": "16:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ROSS V E",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC    40  ",
+                    "title": "FOUNDATION COMP SCI",
+                    "contactHours": 30,
+                    "description": "Introduction to the theoretical underpinnings of computer   science. Topics include propositional predicate logic,   set theory,   functions   and rel ations, counting, mathematical induction and   recursion   (generating   fu nctions).",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 5,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "07930",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 114,
+                        "maxEnroll": 125,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1006",
+                            "building": "NH",
+                            "roomCapacity": 132,
+                            "days": " T R   ",
+                            "beginTime": "14:00",
+                            "endTime": "15:15"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "MIRZA D",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07948",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 32,
+                        "maxEnroll": 32,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "2112",
+                            "building": "GIRV",
+                            "roomCapacity": 42,
+                            "days": "  W    ",
+                            "beginTime": "16:00",
+                            "endTime": "16:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "STEINHART Y",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "SHOWALTER E H",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07955",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 30,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1011",
+                            "building": "387",
+                            "roomCapacity": 42,
+                            "days": "  W    ",
+                            "beginTime": "17:00",
+                            "endTime": "17:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "SHOWALTER E H",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "STEINHART Y",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "07963",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 28,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1448",
+                            "building": "PHELP",
+                            "roomCapacity": 35,
+                            "days": "  W    ",
+                            "beginTime": "18:00",
+                            "endTime": "18:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ABUDAYYEH F J",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "GATIN A",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60251",
+                        "section": "0104",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 24,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN",
+                        "restrictionMajorPass": "12",
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1444",
+                            "building": "PHELP",
+                            "roomCapacity": 35,
+                            "days": "  W    ",
+                            "beginTime": "19:00",
+                            "endTime": "19:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ABUDAYYEH F J",
+                            "functionCode": "Teaching but not in charge"
+                          },
+                          {
+                            "instructor": "GATIN A",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC    99  ",
+                    "title": "INDEPENDENT STUDIES",
+                    "contactHours": 10,
+                    "description": "Independent studies in computer science for advanced students.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": null,
+                    "unitsVariableHigh": 4,
+                    "unitsVariableLow": 1,
+                    "delayedSectioning": "Y",
+                    "inProgressCourse": null,
+                    "gradingOption": "P",
+                    "instructionType": "TUT",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "08037",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": null,
+                        "maxEnroll": null,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": true,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": "L",
+                        "restrictionMajor": null,
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [],
+                        "instructors": []
+                      },
+                      {
+                        "enrollCode": "84137",
+                        "section": "0200",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 1,
+                        "maxEnroll": null,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": true,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": "L",
+                        "restrictionMajor": null,
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [],
+                        "instructors": [
+                          {
+                            "instructor": "BALKIND J M",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC   100  ",
+                    "title": "INTRO TEACH METHODS",
+                    "contactHours": 30,
+                    "description": "Designed to train outstanding undergraduates for learning assistant positio ns in CS courses. Lecture/discussion surveys current research and best prac tices in CS pedagogy including student development theories, different peda gogical techniques, and methods for assessing learning. Students gain exper ience working one-on-one with students, fostering positive learning environ ments, and providing feedback on student work. Students who successfully co mplete this course will earn units by serving as an apprentice undergraduat e learning assistant.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "60269",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": null,
+                        "maxEnroll": 25,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": true,
+                        "restrictionLevel": null,
+                        "restrictionMajor": null,
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3526",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "    F  ",
+                            "beginTime": "12:30",
+                            "endTime": "13:45"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "CONRAD P T",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60277",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": null,
+                        "maxEnroll": 25,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": true,
+                        "restrictionLevel": null,
+                        "restrictionMajor": null,
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "3525",
+                            "building": "PHELP",
+                            "roomCapacity": null,
+                            "days": "  W    ",
+                            "beginTime": "15:00",
+                            "endTime": "17:50"
+                          }
+                        ],
+                        "instructors": []
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC   111  ",
+                    "title": "INT COMPUTAT SCI",
+                    "contactHours": 30,
+                    "description": "Introduction to the numerical algorithms that form the foundations of data science, machine learning, and computational science and engineering. Matri x computation, linear equation systems, eigenvalue and singular value decom positions, numerical optimization. The informed use of mathematical softwar e environments and libraries, such as python/numpy/scipy.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "08045",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 54,
+                        "maxEnroll": 100,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1930",
+                            "building": "BUCHN",
+                            "roomCapacity": 100,
+                            "days": "M W    ",
+                            "beginTime": "09:30",
+                            "endTime": "10:45"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "MATNI Z A",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "08052",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 32,
+                        "maxEnroll": 34,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1112",
+                            "building": "GIRV",
+                            "roomCapacity": 48,
+                            "days": "  W    ",
+                            "beginTime": "16:00",
+                            "endTime": "16:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "SHARMA S",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "08060",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 18,
+                        "maxEnroll": 33,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1508",
+                            "building": "PHELP",
+                            "roomCapacity": 48,
+                            "days": "  W    ",
+                            "beginTime": "17:00",
+                            "endTime": "17:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "CHEN ZICHEN",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "60285",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 4,
+                        "maxEnroll": 33,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1111",
+                            "building": "NH",
+                            "roomCapacity": 42,
+                            "days": "  W    ",
+                            "beginTime": "18:00",
+                            "endTime": "18:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "ZHANG ZHENING",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "quarter": "20222",
+                    "courseId": "CMPSC   130A ",
+                    "title": "DATA STRUCT ALGOR",
+                    "contactHours": 30,
+                    "description": "Data structures and applications with proofs of correctness and analysis. H ash tables, priority queues (heaps); balanced search trees. Graph traversal techniques and their applications.",
+                    "college": "ENGR",
+                    "objLevelCode": "U",
+                    "subjectArea": "CMPSC   ",
+                    "unitsFixed": 4,
+                    "unitsVariableHigh": null,
+                    "unitsVariableLow": null,
+                    "delayedSectioning": null,
+                    "inProgressCourse": null,
+                    "gradingOption": "L",
+                    "instructionType": "LEC",
+                    "onLineCourse": false,
+                    "deptCode": "CMPSC",
+                    "generalEducation": [],
+                    "classSections": [
+                      {
+                        "enrollCode": "08078",
+                        "section": "0100",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 55,
+                        "maxEnroll": 77,
+                        "secondaryStatus": "R",
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1902",
+                            "building": "PSYCH",
+                            "roomCapacity": 77,
+                            "days": " T R   ",
+                            "beginTime": "09:30",
+                            "endTime": "10:45"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "LOKSHTANOV D",
+                            "functionCode": "Teaching and in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "08086",
+                        "section": "0101",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 9,
+                        "maxEnroll": 24,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1445",
+                            "building": "PHELP",
+                            "roomCapacity": 35,
+                            "days": "    F  ",
+                            "beginTime": "09:00",
+                            "endTime": "09:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "TURNLUND K K",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "08094",
+                        "section": "0102",
+                        "session": null,
+                        "classClosed": null,
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 20,
+                        "maxEnroll": 22,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "2108",
+                            "building": "GIRV",
+                            "roomCapacity": 36,
+                            "days": "    F  ",
+                            "beginTime": "10:00",
+                            "endTime": "10:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "DE A",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      },
+                      {
+                        "enrollCode": "08102",
+                        "section": "0103",
+                        "session": null,
+                        "classClosed": "Y",
+                        "courseCancelled": null,
+                        "gradingOptionCode": null,
+                        "enrolledTotal": 26,
+                        "maxEnroll": 31,
+                        "secondaryStatus": null,
+                        "departmentApprovalRequired": false,
+                        "instructorApprovalRequired": false,
+                        "restrictionLevel": null,
+                        "restrictionMajor": "+CMPSC+CMPEN+CPSCI+EE",
+                        "restrictionMajorPass": null,
+                        "restrictionMinor": null,
+                        "restrictionMinorPass": null,
+                        "concurrentCourses": [],
+                        "timeLocations": [
+                          {
+                            "room": "1116",
+                            "building": "GIRV",
+                            "roomCapacity": 42,
+                            "days": "    F  ",
+                            "beginTime": "11:00",
+                            "endTime": "11:50"
+                          }
+                        ],
+                        "instructors": [
+                          {
+                            "instructor": "SHAFIUZZAMAN",
+                            "functionCode": "Teaching but not in charge"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+
+                """;
+
+}

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
@@ -11,11 +11,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-class CoursePageTests {
+public class CoursePageTests {
 
 
     @Test
-    void convertsCoursePageToObject()  {
+    public void convertsCoursePageToObject()  {
         CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON);
         assertEquals(1, cp.getPageNumber());
         assertEquals(10, cp.getPageSize());
@@ -24,7 +24,7 @@ class CoursePageTests {
 
 
     @Test
-    void convertsMath3BCoursePageToObject() throws JsonProcessingException {
+    public void convertsMath3BCoursePageToObject() throws JsonProcessingException {
         CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
         assertEquals(1, cp.getPageNumber());
         assertEquals(10, cp.getPageSize());
@@ -37,7 +37,7 @@ class CoursePageTests {
     }
 
     @Test
-    void convertedSectionsConvertsProperly() throws JsonProcessingException {
+    public void convertedSectionsConvertsProperly() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
 
         CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
@@ -50,7 +50,7 @@ class CoursePageTests {
     }
 
     @Test
-    void throwsExceptionOnBadJSON() throws Exception {
+    public void throwsExceptionOnBadJSON() throws Exception {
         CoursePage cp = CoursePage.fromJSON("this is not valid JSON");
         assertNull(cp);
     }

--- a/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/CoursePageTests.java
@@ -1,0 +1,58 @@
+package edu.ucsb.cs156.courses.documents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class CoursePageTests {
+
+
+    @Test
+    void convertsCoursePageToObject()  {
+        CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON);
+        assertEquals(1, cp.getPageNumber());
+        assertEquals(10, cp.getPageSize());
+        assertEquals(49, cp.getTotal());
+    }
+
+
+    @Test
+    void convertsMath3BCoursePageToObject() throws JsonProcessingException {
+        CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
+        assertEquals(1, cp.getPageNumber());
+        assertEquals(10, cp.getPageSize());
+        assertEquals(1, cp.getTotal());
+
+        List<ConvertedSection> cs = cp.convertedSections();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(cs);
+    }
+
+    @Test
+    void convertedSectionsConvertsProperly() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        CoursePage cp = CoursePage.fromJSON(CoursePageFixtures.COURSE_PAGE_JSON_MATH3B);
+        List<ConvertedSection> convertedSections = cp.convertedSections();
+      
+        List<ConvertedSection> expected = 
+            objectMapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B,new TypeReference<List<ConvertedSection>>() {});
+                  
+        assertEquals(expected, convertedSections);
+    }
+
+    @Test
+    void throwsExceptionOnBadJSON() throws Exception {
+        CoursePage cp = CoursePage.fromJSON("this is not valid JSON");
+        assertNull(cp);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -9,6 +9,11 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withUnauthorizedRequest;
 
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +25,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CoursePageFixtures;
 
 @RestClientTest(UCSBCurriculumService.class)
 public class UCSBCurriculumServiceTests {
@@ -45,16 +53,16 @@ public class UCSBCurriculumServiceTests {
         String level = "L";
 
         String expectedParams = String.format(
-            "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
-            subjectArea, level, 1, 100, "true");
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, level, 1, 100, "true");
         String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
 
         this.mockRestServiceServer.expect(requestTo(expectedURL))
-            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("ucsb-api-version", "1.0"))
-            .andExpect(header("ucsb-api-key", apiKey))
-            .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
 
         String result = ucs.getJSON(subjectArea, quarter, level);
 
@@ -71,16 +79,16 @@ public class UCSBCurriculumServiceTests {
         String level = "A";
 
         String expectedParams = String.format(
-            "?quarter=%s&subjectCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
-            quarter, subjectArea, 1, 100, "true");
+                "?quarter=%s&subjectCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s",
+                quarter, subjectArea, 1, 100, "true");
         String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
 
         this.mockRestServiceServer.expect(requestTo(expectedURL))
-            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("ucsb-api-version", "1.0"))
-            .andExpect(header("ucsb-api-key", apiKey))
-            .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
 
         String result = ucs.getJSON(subjectArea, quarter, level);
 
@@ -92,7 +100,7 @@ public class UCSBCurriculumServiceTests {
         String expectedResult = "{\"error\": \"401: Unauthorized\"}";
 
         when(restTemplate.exchange(any(String.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
-            .thenThrow(HttpClientErrorException.class);
+                .thenThrow(HttpClientErrorException.class);
 
         String subjectArea = "CMPSC";
         String quarter = "20201";
@@ -104,11 +112,11 @@ public class UCSBCurriculumServiceTests {
         String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
 
         this.mockRestServiceServer.expect(requestTo(expectedURL))
-            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("ucsb-api-version", "1.0"))
-            .andExpect(header("ucsb-api-key", apiKey))
-            .andRespond(withUnauthorizedRequest());
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withUnauthorizedRequest());
 
         String result = ucs.getJSON(subjectArea, quarter, level);
 
@@ -121,11 +129,11 @@ public class UCSBCurriculumServiceTests {
         String expectedURL = UCSBCurriculumService.SUBJECTS_ENDPOINT;
 
         this.mockRestServiceServer.expect(requestTo(expectedURL))
-            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("ucsb-api-version", "1.0"))
-            .andExpect(header("ucsb-api-key", apiKey))
-            .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
 
         String result = ucs.getSubjectsJSON();
         assertEquals(expectedResult, result);
@@ -137,12 +145,41 @@ public class UCSBCurriculumServiceTests {
         String expectedURL = UCSBCurriculumService.SUBJECTS_ENDPOINT;
 
         this.mockRestServiceServer.expect(requestTo(expectedURL))
-            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
-            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
-            .andRespond(withUnauthorizedRequest());
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withUnauthorizedRequest());
 
         String result = ucs.getSubjectsJSON();
         assertEquals(expectedResult, result);
+    }
+
+    @Test
+    public void test_getConvertedSections() throws Exception {
+        String expectedResult = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
+
+        String subjectArea = "MATH";
+        String quarter = "20222";
+        String level = "L";
+
+        String expectedParams = String.format(
+                "?quarter=%s&subjectCode=%s&objLevelCode=%s&pageNumber=%d&pageSize=%d&includeClassSections=%s", quarter,
+                subjectArea, level, 1, 100, "true");
+        String expectedURL = UCSBCurriculumService.CURRICULUM_ENDPOINT + expectedParams;
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("ucsb-api-version", "1.0"))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<ConvertedSection> convertedSections = ucs.getConvertedSections(subjectArea, quarter, level);
+        List<ConvertedSection> expected = objectMapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B,
+                new TypeReference<List<ConvertedSection>>() {
+                });
+
+        assertEquals(expected, convertedSections);
     }
 
 }


### PR DESCRIPTION
In this PR, we add:

* A set of _document classes_  that corresponds to the hierarchy of the JSON returned by the UCSB Developer API.
   - The top level object is  `CoursePage`, which corresponds to the top level object returned by the Curriculum Search API
   - Under that, the next level is `Course` which corresponds to one object in the `"classes"` list in the `CoursePage` object, and which also represents the object that is found in the MongoDB database collection `courses`
   - Under that, there are objects that represent all of the parts of the `Course` object, including sections, etc.
* A class `ConvertedSection` which allows for the flattening of information representing courses and course sections, so that each `ConvertedSection` object has both the `Course` level information and the `Section` level information
* Tests for each of these
* A new method in the `UCSBCurriculumService` that will return a `List<ConvertedSection>`;

Note that the fixture `CONVERTED_SECTIONS_JSON_MATH5B` can be used as the basis of a new fixture for writing frontend components that display section level info, while the backend is being worked on.

# Testing

There is no user facing functionality in this PR that can be tested; for example, while we have implemented a new method in the `UCSBCurriculumService`, exposing that through an API endpoint (so, for example, it could be tested using Swagger) is being left as an exercise to the CMPSC 156 students.  Therefore, the only way to test is through unit testing, which is included in this PR.  There is 100% test coverage on Jacoco, and through Pitest Mutation testing.